### PR TITLE
Add content_for? method for checking presence of named block

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -17,5 +17,9 @@ module NicePartials
     def content_for(name, content = nil, options = {}, &block)
       @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
     end
+
+    def content_for?(name)
+      @view_context.content_for?("#{name}_#{@key}".to_sym)
+    end
   end
 end


### PR DESCRIPTION
This PR wraps [Rails' `content_for?` method](https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for-3F), which might be expected.

Happy to add documentation for it—let me know where this could fit.