### PR TITLE
Customise content areas with options_for

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,10 +1,13 @@
 module NicePartials
   class Partial
+    DEFAULT_CONTENT_FOR_OPTIONS = [:flush]
+
     delegate_missing_to :@view_context
 
     def initialize(view_context)
       @view_context = view_context
       @key = SecureRandom.uuid
+      @content_options = {}
     end
 
     def yield(name = nil)
@@ -17,11 +20,33 @@ module NicePartials
     end
 
     def content_for(name, content = nil, options = {}, &block)
-      @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
+      if content || block_given?
+        if block_given?
+          options = content || {}
+          content = @view_context.capture(&block)
+        end
+
+        options_for(name, options.without(*DEFAULT_CONTENT_FOR_OPTIONS))
+      end
+
+      @view_context.content_for(name_for(name), content, options.slice(*DEFAULT_CONTENT_FOR_OPTIONS))
     end
 
     def content_for?(name)
-      @view_context.content_for?("#{name}_#{@key}".to_sym)
+      @view_context.content_for?(name_for(name))
+    end
+
+    def options_for(name, options = nil)
+      if options
+        @content_options[name_for(name)] = options
+        nil
+      else
+        @content_options[name_for(name)] || {}
+      end
+    end
+
+    def name_for(name)
+      "#{name}_#{@key}".to_sym
     end
   end
 end


### PR DESCRIPTION
This pull requests extends Nice Partials to include content area options via `options_for(:name)`.

This is useful for customising attributes within a Nice Partial. A (contrived) example:

```erb
<%# _list_item.html.erb %>
<% yield p = np %>
<h2><%= link_to p.content_for(:link), object %></h2>
```

Could be enhanced to provide customised HTML attributes with:

```erb
<%# _list_item.html.erb %>
<% yield p = np %>
<h2><%= link_to p.content_for(:link), object, p.options_for(:link) %></h2>
```

```erb
<%# index.html.erb %>
<h1>Posts</h1>
<% @posts.each do |post| %>
  <%= render 'list_item', object: post do |p| %>
    <% p.content_for :link, 'Hello, World!', class: 'font-bold text-lg' %>
  <% end %>
<% end %>
```

`p.options_for` can also be used on its own to set content, following a similar pattern to `content_for` e.g.:

```erb
<%# _list_item.html.erb %>
<% yield p = np %>
<h2><%= link_to object.title, object, p.options_for(:link) %></h2>
```

```erb
<%# index.html.erb %>
<h1>Posts</h1>
<% @posts.each do |post| %>
  <%= render 'list_item', object: post do |p| %>
    <% p.options_for :link, class: 'font-bold text-lg' %>
  <% end %>
<% end %>
```

Closes #4