### PR TITLE
Customisation with options

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,9 +1,11 @@
 module NicePartials
   class Partial
+    attr_reader :options
     delegate_missing_to :@view_context
 
-    def initialize(view_context)
+    def initialize(view_context, options = {})
       @view_context = view_context
+      @options = options
       @key = SecureRandom.uuid
     end
 


### PR DESCRIPTION
This pull request adds a simple customisation enhancement. It allows Nice Partials to provide a default options object to the parent view via `np`, and made accesible from `p.options`. This can be modified by the parent view as needed, effectively allowing it to "reach in" and modify the internals of the partial for a given case. 

For example, classes can be modified for that _occasional_ case that needs different: in this case, adding `rounded-none` and removing `rounded`:

```erb
# app/views/posts/index.html.erb
<%= render 'components/card', class: 'rounded-none' do |p| %>
  <% p.options[:class].delete('rounded') %>
  …
<% end %>
```

``` erb
# app/views/components/_card.html.erb
<% yield p = np(class: ['card', 'rounded', local_assigns[:class]]) %>
<div class="<%= token_list(p.options[:class]) %>">
  …
</div>
```
**What's happening here?**
1. The card partial sets up the default options hash with class names, merging in those passed in as locals.
2. The index template passes in `rounded-none`as a local, then deletes the `rounded` class
3. The card partial sets the class attribute with the now-modified `options[:class]` using [`token_list`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list) in Rails 6.1
