### PR TITLE
Support for Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 
 rvm:
+- 3.0
 - 2.7
 - 2.6
 - 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## CHANGELOG
 
+* Add support for Ruby 3.0
+
 ### 0.1.0
 
 * Initial release

--- a/nice_partials.gemspec
+++ b/nice_partials.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.0"
+  gem.required_ruby_version = ">= 2.0"
 
   gem.add_dependency "actionview", '>= 4.2.6'
 end


### PR DESCRIPTION
Relax the Ruby version constrains in the `.gemspec` file, and run CI
against Ruby 3.0.