### PR TITLE
Use on_load hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## CHANGELOG
 
+* Rely on `ActiveSupport.on_load :action_view`
 * Add support for Ruby 3.0
 
 ### 0.1.0

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -16,4 +16,6 @@ def nice_partials_locale_prefix_from_view_context_and_block(context, block)
   partial_location.split('.').first.gsub('/_', '/').gsub('/', '.')
 end
 
-ActionView::Base.send :include, NicePartials::Helper
+ActiveSupport.on_load :action_view do
+  include NicePartials::Helper
+end


### PR DESCRIPTION
Prior to this change, `rails server` raises the following error:

```
/Users/HOME/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/gems/actiontext-6.1.3.1/app/helpers/action_text/tag_helper.rb:40:in `<module:Helpers>': superclass mismatch for class ActionText (TypeError)
        from /Users/HOME/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/gems/actiontext-6.1.3.1/app/helpers/action_text/tag_helper.rb:39:in `<main>'
```

To resolve the loading issue, mix the `NicePartials::Helper` into
`ActionView::Base` from within an [ActiveSupport.on_load
:action_view][on_load] hook.

[on_load]: https://guides.rubyonrails.org/engines.html#avoid-loading-rails-frameworks