### PR TITLE
fix: change t method signature

### DIFF
--- a/lib/nice_partials/helper.rb
+++ b/lib/nice_partials/helper.rb
@@ -15,7 +15,7 @@ module NicePartials::Helper
     @_nice_partials_t_prefixes.pop
   end
 
-  def t(key, options = {})
+  def t(key, **options)
     if @_nice_partials_t_prefixes&.any? && key.first == '.'
       key = "#{@_nice_partials_t_prefixes.last}#{key}"
     end


### PR DESCRIPTION
Currently, get the following deprecation warning for the `t` method.

> lib/nice_partials/helper.rb:23: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call