### PR TITLE
Clarify translation context popping

### DIFF
--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -5,8 +5,8 @@ require_relative "nice_partials/helper"
 require_relative "nice_partials/monkey_patch"
 
 module NicePartials
-  def self.locale_prefix_from_view_context_and_block(context, block)
-    root_paths = context.view_renderer.lookup_context.view_paths.map(&:path)
+  def self.locale_prefix_from(lookup_context, block)
+    root_paths = lookup_context.view_paths.map(&:path)
     partial_location = block.source_location.first.dup
     root_paths.each { |path| partial_location.gsub!(/^#{path}\//, '') }
     partial_location.split('.').first.gsub('/_', '/').gsub('/', '.')

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -5,14 +5,12 @@ require_relative "nice_partials/helper"
 require_relative "nice_partials/monkey_patch"
 
 module NicePartials
-end
-
-# TODO Is there somewhere better we can put this?
-def nice_partials_locale_prefix_from_view_context_and_block(context, block)
-  root_paths = context.view_renderer.lookup_context.view_paths.map(&:path)
-  partial_location = block.source_location.first.dup
-  root_paths.each { |path| partial_location.gsub!(/^#{path}\//, '') }
-  partial_location.split('.').first.gsub('/_', '/').gsub('/', '.')
+  def self.locale_prefix_from_view_context_and_block(context, block)
+    root_paths = context.view_renderer.lookup_context.view_paths.map(&:path)
+    partial_location = block.source_location.first.dup
+    root_paths.each { |path| partial_location.gsub!(/^#{path}\//, '') }
+    partial_location.split('.').first.gsub('/_', '/').gsub('/', '.')
+  end
 end
 
 ActiveSupport.on_load :action_view do

--- a/lib/nice_partials/helper.rb
+++ b/lib/nice_partials/helper.rb
@@ -4,20 +4,4 @@ module NicePartials::Helper
   def np
     NicePartials::Partial.new(self)
   end
-
-  def with_nice_partials_t_prefix(lookup_context, block)
-    @_nice_partials_t_prefixes ||= []
-    @_nice_partials_t_prefixes << (block ? NicePartials.locale_prefix_from(lookup_context, block) : '')
-    yield
-  ensure
-    @_nice_partials_t_prefixes.pop
-  end
-
-  def t(key, options = {})
-    if (prefix = @_nice_partials_t_prefixes&.last) && key.first == '.'
-      key = "#{prefix}#{key}"
-    end
-
-    super(key, **options)
-  end
 end

--- a/lib/nice_partials/helper.rb
+++ b/lib/nice_partials/helper.rb
@@ -5,19 +5,17 @@ module NicePartials::Helper
     NicePartials::Partial.new(self)
   end
 
-  def nice_partials_push_t_prefix(prefix)
+  def with_nice_partials_t_prefix(lookup_context, block)
     @_nice_partials_t_prefixes ||= []
-    @_nice_partials_t_prefixes << prefix
-  end
-
-  def nice_partials_pop_t_prefix
-    @_nice_partials_t_prefixes ||= []
+    @_nice_partials_t_prefixes << (block ? NicePartials.locale_prefix_from(lookup_context, block) : '')
+    yield
+  ensure
     @_nice_partials_t_prefixes.pop
   end
 
   def t(key, options = {})
-    if @_nice_partials_t_prefixes&.any? && key.first == '.'
-      key = "#{@_nice_partials_t_prefixes.last}#{key}"
+    if (prefix = @_nice_partials_t_prefixes&.last) && key.first == '.'
+      key = "#{prefix}#{key}"
     end
 
     super(key, **options)

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -13,18 +13,8 @@ class ActionView::PartialRenderer
       context.nice_partials_push_t_prefix ''
     end
 
-    begin
-      result = original_render(partial, context, block)
-    rescue Exception => exception
-      # If there was some sort of exception thrown, we also need to pop the `t` prefix.
-      # This provides compatibility with other libraries that depend on catching exceptions from the view renderer.
-      context.nice_partials_pop_t_prefix
-      raise exception
-    end
-
-    # Whether there was a block or not, pop off whatever we put on the stack.
+    original_render(partial, context, block)
+  ensure
     context.nice_partials_pop_t_prefix
-
-    return result
   end
 end

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -17,14 +17,16 @@ module NicePartials::RenderingWithLocalePrefix
   end
 
   def capture(*, &block)
-    if block_given?
+    if block
       partial_prefix = NicePartials.locale_prefix_from(lookup_context, block)
       nice_partials_push_t_prefix(partial_prefix)
+    else
+      nice_partials_push_t_prefix ''
     end
 
     super
   ensure
-    nice_partials_pop_t_prefix if block_given?
+    nice_partials_pop_t_prefix
   end
 end
 

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -9,6 +9,24 @@ module NicePartials::RenderingWithLocalePrefix
   def capture(*, &block)
     with_nice_partials_t_prefix(lookup_context, block) { super }
   end
+
+  def t(key, options = {})
+    if (prefix = @_nice_partials_t_prefixes&.last) && key.first == '.'
+      key = "#{prefix}#{key}"
+    end
+
+    super(key, **options)
+  end
+
+  private
+
+  def with_nice_partials_t_prefix(lookup_context, block)
+    @_nice_partials_t_prefixes ||= []
+    @_nice_partials_t_prefixes << (block ? NicePartials.locale_prefix_from(lookup_context, block) : '')
+    yield
+  ensure
+    @_nice_partials_t_prefixes.pop
+  end
 end
 
 ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -15,6 +15,17 @@ module NicePartials::RenderingWithLocalePrefix
   ensure
     nice_partials_pop_t_prefix
   end
+
+  def capture(*, &block)
+    if block_given?
+      partial_prefix = NicePartials.locale_prefix_from(lookup_context, block)
+      nice_partials_push_t_prefix(partial_prefix)
+    end
+
+    super
+  ensure
+    nice_partials_pop_t_prefix if block_given?
+  end
 end
 
 ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -3,30 +3,11 @@
 module NicePartials::RenderingWithLocalePrefix
   # See `content_for` in `lib/nice_partials/partial.rb` for something similar.
   def render(*, &block)
-    if block
-      partial_prefix = NicePartials.locale_prefix_from(lookup_context, block)
-      nice_partials_push_t_prefix partial_prefix
-    else
-      # Render partial calls with no block should disable any prefix magic.
-      nice_partials_push_t_prefix ''
-    end
-
-    super
-  ensure
-    nice_partials_pop_t_prefix
+    with_nice_partials_t_prefix(lookup_context, block) { super }
   end
 
   def capture(*, &block)
-    if block
-      partial_prefix = NicePartials.locale_prefix_from(lookup_context, block)
-      nice_partials_push_t_prefix(partial_prefix)
-    else
-      nice_partials_push_t_prefix ''
-    end
-
-    super
-  ensure
-    nice_partials_pop_t_prefix
+    with_nice_partials_t_prefix(lookup_context, block) { super }
   end
 end
 

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -6,7 +6,7 @@ class ActionView::PartialRenderer
   # See `content_for` in `lib/nice_partials/partial.rb` for something similar.
   def render(partial, context, block)
     if block
-      partial_prefix = nice_partials_locale_prefix_from_view_context_and_block(context, block)
+      partial_prefix = NicePartials.locale_prefix_from_view_context_and_block(context, block)
       context.nice_partials_push_t_prefix partial_prefix
     else
       # Render partial calls with no block should disable any prefix magic.

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -1,20 +1,20 @@
 # Monkey patch required to make `t` work as expected. Is this evil?
 # TODO Do we need to monkey patch other types of renderers as well?
-class ActionView::PartialRenderer
-  alias_method :original_render, :render
-
+module NicePartials::RenderingWithLocalePrefix
   # See `content_for` in `lib/nice_partials/partial.rb` for something similar.
-  def render(partial, context, block)
+  def render(*, &block)
     if block
-      partial_prefix = NicePartials.locale_prefix_from_view_context_and_block(context, block)
-      context.nice_partials_push_t_prefix partial_prefix
+      partial_prefix = NicePartials.locale_prefix_from(lookup_context, block)
+      nice_partials_push_t_prefix partial_prefix
     else
       # Render partial calls with no block should disable any prefix magic.
-      context.nice_partials_push_t_prefix ''
+      nice_partials_push_t_prefix ''
     end
 
-    original_render(partial, context, block)
+    super
   ensure
-    context.nice_partials_pop_t_prefix
+    nice_partials_pop_t_prefix
   end
 end
+
+ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -19,7 +19,7 @@ module NicePartials
     # See the `ActionView::PartialRenderer` monkey patch in `lib/nice_partials/monkey_patch.rb` for something similar.
     def content_for(name, content = nil, options = {}, &block)
       if block_given?
-        partial_prefix = NicePartials.locale_prefix_from_view_context_and_block(@view_context, block)
+        partial_prefix = NicePartials.locale_prefix_from(@view_context.lookup_context, block)
         @view_context.nice_partials_push_t_prefix(partial_prefix)
       end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -23,13 +23,9 @@ module NicePartials
         @view_context.nice_partials_push_t_prefix(partial_prefix)
       end
 
-      result = @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
-
-      if block_given?
-        @view_context.nice_partials_pop_t_prefix
-      end
-
-      return result
+      @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
+    ensure
+      @view_context.nice_partials_pop_t_prefix if block_given?
     end
 
     def content_for?(name)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -18,14 +18,7 @@ module NicePartials
 
     # See the `ActionView::PartialRenderer` monkey patch in `lib/nice_partials/monkey_patch.rb` for something similar.
     def content_for(name, content = nil, options = {}, &block)
-      if block_given?
-        partial_prefix = NicePartials.locale_prefix_from(@view_context.lookup_context, block)
-        @view_context.nice_partials_push_t_prefix(partial_prefix)
-      end
-
       @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
-    ensure
-      @view_context.nice_partials_pop_t_prefix if block_given?
     end
 
     def content_for?(name)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -19,7 +19,7 @@ module NicePartials
     # See the `ActionView::PartialRenderer` monkey patch in `lib/nice_partials/monkey_patch.rb` for something similar.
     def content_for(name, content = nil, options = {}, &block)
       if block_given?
-        partial_prefix = nice_partials_locale_prefix_from_view_context_and_block(@view_context, block)
+        partial_prefix = NicePartials.locale_prefix_from_view_context_and_block(@view_context, block)
         @view_context.nice_partials_push_t_prefix(partial_prefix)
       end
 


### PR DESCRIPTION
This shifts our `t` overrides to store the value on the stack since we only ever care about the last value on the array.

@andrewculver some of this is hard to test, since I don't have an app on me. How have you vetted this before?