### PR TITLE
Custom content sections

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,7 +1,8 @@
 module NicePartials
   class Partial
-    def initialize(view_context)
+    def initialize(view_context, *names)
       @view_context = view_context
+      names.each { |name| generate_attribute_methods(name) }
     end
 
     def yield(name = nil)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -4,7 +4,7 @@ module NicePartials
 
     def initialize(view_context)
       @view_context = view_context
-      @key = SecureRandom.uuid
+      @content = {}
     end
 
     def yield(name = nil)
@@ -17,12 +17,19 @@ module NicePartials
     end
 
     # See the `ActionView::PartialRenderer` monkey patch in `lib/nice_partials/monkey_patch.rb` for something similar.
-    def content_for(name, content = nil, options = {}, &block)
-      @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
+    def content_for(name, content = nil, &block)
+      content = capture(&block) if block
+
+      if content
+        @content[name] = ActiveSupport::SafeBuffer.new(content.to_s)
+        nil
+      else
+        @content[name].presence
+      end
     end
 
     def content_for?(name)
-      @view_context.content_for?("#{name}_#{@key}".to_sym)
+      @content[name].present?
     end
   end
 end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -31,7 +31,7 @@ module NicePartials
       if @view_context.respond_to?(meth)
         @view_context.send(meth, *args, **options, &block)
       else
-        generate_attribute_methods(meth)
+        generate_attribute_methods meth.to_s.sub(/(\?|=)/, "")
         public_send(meth, *args, **options, &block)
       end
     end
@@ -39,8 +39,6 @@ module NicePartials
     private
 
     def generate_attribute_methods(name)
-      name = name.to_s.sub(/(\?|=)/, "")
-
       self.class.class_eval <<~RUBY, __FILE__, __LINE__ + 1
         def #{name}(content = nil, &block)
           if content || block

--- a/test/fixtures/_card_with_options.html.erb
+++ b/test/fixtures/_card_with_options.html.erb
@@ -1,0 +1,4 @@
+<%= yield p = np %>
+<% p.title class: "some-class", data: { controller: "yup" } %>
+
+<%= tag.span **p.title.options %>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,9 +1,7 @@
 <%= render "card", title: "Some Title" do |p| %>
-  <% p.content_for :body do %>
-    Lorem Ipsum
-  <% end %>
+  <% p.body "Lorem Ipsum" %>
 
-  <% p.content_for :image do %>
+  <% p.image do %>
     <img src="https://example.com/image.jpg" />
   <% end %>
 <% end %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -20,4 +20,10 @@ class RendererTest < NicePartials::Test
     assert_rendered "Lorem Ipsum"
     assert_rendered "https://example.com/image.jpg"
   end
+
+  test "render nice partial card with options" do
+    render("card_with_options")
+
+    assert_select "span.some-class[data-controller='yup']"
+  end
 end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -7,6 +7,12 @@ class RendererTest < NicePartials::Test
     assert_rendered "hello from nice partials"
   end
 
+  test "render basic nice partial with custom name" do
+    render("basic") { |p| p.message "hello from nice partials" }
+
+    assert_rendered "hello from nice partials"
+  end
+
   test "render nice partial in card template" do
     render(template: "card_test")
 


### PR DESCRIPTION
This adds a layer on top `NicePartial::Partial`s `content_for` API to have custom named sections and storing more than just string content. A slightly different take to https://github.com/bullet-train-co/nice_partials/pull/9

Here we define a `title` content section with some options that we can then refer to later and use to build other content:

```ruby
<%= yield p = np %>
<% p.title class: "some-class", data: { controller: "yup" } %>
<%= tag.span **p.title.options %>
```

With this abstraction we could potentially also allow merging two `NicePartial::Partial`s to allow for https://github.com/bullet-train-co/nice_partials/issues/11, so delegation really becomes copy the passed in sections to the new `NicePartial::Partial` or something like that.

Also curious what @domchristie and @seanpdoyle thinks of something like this, since they've done a lot of work in this area.