### PR TITLE
Store t prefix on the stack

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -11,7 +11,7 @@ module NicePartials::RenderingWithLocalePrefix
   end
 
   def t(key, options = {})
-    if (prefix = @_nice_partials_t_prefixes&.last) && key.first == '.'
+    if (prefix = @_nice_partials_t_prefix) && key.first == '.'
       key = "#{prefix}#{key}"
     end
 
@@ -21,11 +21,11 @@ module NicePartials::RenderingWithLocalePrefix
   private
 
   def with_nice_partials_t_prefix(lookup_context, block)
-    @_nice_partials_t_prefixes ||= []
-    @_nice_partials_t_prefixes << (block ? NicePartials.locale_prefix_from(lookup_context, block) : '')
+    _nice_partials_t_prefix = @_nice_partials_t_prefix
+    @_nice_partials_t_prefix = block ? NicePartials.locale_prefix_from(lookup_context, block) : nil
     yield
   ensure
-    @_nice_partials_t_prefixes.pop
+    @_nice_partials_t_prefix = _nice_partials_t_prefix
   end
 end
 


### PR DESCRIPTION
For the array storage we only care about the last value, which means
that we're able to just store the prefix in a single string variable.

We can still push the prefix if we're nesting further, or reset it to
not leak if we're performing a call without a block.

We can then pop/revert the prefix by resetting the variable.