### PR TITLE
Remove unneeded `render` override

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -2,10 +2,6 @@
 # TODO Do we need to monkey patch other types of renderers as well?
 module NicePartials::RenderingWithLocalePrefix
   # See `content_for` in `lib/nice_partials/partial.rb` for something similar.
-  def render(*, &block)
-    with_nice_partials_t_prefix(lookup_context, block) { super }
-  end
-
   def capture(*, &block)
     with_nice_partials_t_prefix(lookup_context, block) { super }
   end

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -1,7 +1,6 @@
 # Monkey patch required to make `t` work as expected. Is this evil?
 # TODO Do we need to monkey patch other types of renderers as well?
 module NicePartials::RenderingWithLocalePrefix
-  # See `content_for` in `lib/nice_partials/partial.rb` for something similar.
   def capture(*, &block)
     with_nice_partials_t_prefix(lookup_context, block) { super }
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -16,7 +16,6 @@ module NicePartials
       class_eval &block
     end
 
-    # See the `ActionView::PartialRenderer` monkey patch in `lib/nice_partials/monkey_patch.rb` for something similar.
     def content_for(name, content = nil, options = {}, &block)
       @view_context.content_for("#{name}_#{@key}".to_sym, content, options, &block)
     end


### PR DESCRIPTION
When a partial calls `yield`, it'll automatically call into here and run
`_layout_for`:
https://github.com/rails/rails/blob/c704da66de59262f4e88824589ae4eddefb6ed4a/actionview/lib/action_view/renderer/partial_renderer.rb#L252

If `_layout_for` is passed a block, it'll call `capture` here:
https://github.com/rails/rails/blob/c704da66de59262f4e88824589ae4eddefb6ed4a/actionview/lib/action_view/helpers/rendering_helper.rb#L101

Since we're overriding `capture`, we can omit the `render` override now.

Note: `_layout_for` has a fallback to `super` in case it's passed a Symbol argument,
e.g. `yield :body`, in which it behaves like `content_for` (as `content_for` calls `view_flow.get`).
https://github.com/rails/rails/blob/c704da66de59262f4e88824589ae4eddefb6ed4a/actionview/lib/action_view/context.rb#L29