### PR TITLE
Automatically yield `np` based on block arity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,21 @@ You only need to use Nice Partials when:
 
  - you want to specifically isolate your helper methods for a specific partial.
 
-### Use Nice Partials in a partial
+### Invoking Nice Partials
 
-To invoke nice partials, start your partial file with the following:
+Nice Partials is invoked automatically when you render your partial with a block that takes a single parameter like so:
 
 ```html+erb
-<% yield p = np %>
+<%= render 'components/card' do |p| %>
+  <%= p.content_for :some_section %>
+    Some content!
+  <% end %>
+<% end %>
 ```
 
-Here's what is happening here:
+It's always been natural to pass blocks to a partial in Rails, but not to pass blocks that take parameters, so when you do this, we know it's a partial that uses Nice Partials.
 
-  - `yield` executes the block we receive when someone uses our partial.
-  - `np` fetches an instance of the generic class that helps isolate our content buffers and helper methods.
-  - `p = np` ensures we have a reference to that object in this partial.
-  - `yield p = np` ensures the developer using this partial also has a reference to that object, so they can define what goes in the various content buffers.
-
-(This is, [as far as we know](https://github.com/bullet-train-co/nice_partials/issues/1), the minimum viable invocation.)
-
-Once you've done this at the top of your partial file, you can then use `<%= p.yield :some_section %>` to render whatever content areas you want to be passed into your partial.
-
+Now within the partial file itself, you can use `<%= p.yield :some_section %>` to render whatever content areas you want to be passed into your partial.
 
 ### Defining and using well isolated helper methods
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You only need to use Nice Partials when:
 
  - you want to specifically isolate your helper methods for a specific partial.
 
-### Invoking Nice Partials
+### Using Nice Partials
 
 Nice Partials is invoked automatically when you render your partial with a block that takes a single parameter like so:
 

--- a/lib/nice_partials/helper.rb
+++ b/lib/nice_partials/helper.rb
@@ -1,7 +1,8 @@
 require_relative "partial"
 
 module NicePartials::Helper
-  def np
+  def nice_partial
     NicePartials::Partial.new(self)
   end
+  alias_method :np, :nice_partial
 end

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -29,7 +29,7 @@ module NicePartials::RenderingWithAutoContext
 
   def render(options = {}, locals = {}, &block)
     _content = content
-    _layout_for(@content = np) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
+    _layout_for(@content = np, &block) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
     super
   ensure
     @content = _content

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -28,7 +28,7 @@ module NicePartials::RenderingWithAutoContext
   attr_reader :content
 
   def render(options = {}, locals = {}, &block)
-    _content, @content = content, np
+    _content, @content = content, nice_partial
     @content.capture(block)
     super
   ensure

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -26,6 +26,11 @@ end
 
 module NicePartials::RenderingWithAutoContext
   attr_reader :content
+  alias_method :_p, :content
+
+  def p(*args)
+    args.empty? ? _p : super
+  end
 
   def render(options = {}, locals = {}, &block)
     _content, @content = content, nice_partial
@@ -33,10 +38,6 @@ module NicePartials::RenderingWithAutoContext
     super
   ensure
     @content = _content
-  end
-
-  def p(*args)
-    args.empty? ? content : super
   end
 end
 

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -28,8 +28,8 @@ module NicePartials::RenderingWithAutoContext
   attr_reader :content
 
   def render(options = {}, locals = {}, &block)
-    _content = content
-    _layout_for(@content = np, &block) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
+    _content, @content = content, np
+    @content.output_buffer = _layout_for(@content, &block) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
     super
   ensure
     @content = _content

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -29,7 +29,7 @@ module NicePartials::RenderingWithAutoContext
 
   def render(options = {}, locals = {}, &block)
     _content, @content = content, np
-    @content.output_buffer = _layout_for(@content, &block) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
+    @content.capture(block)
     super
   ensure
     @content = _content

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -24,4 +24,17 @@ module NicePartials::RenderingWithLocalePrefix
   end
 end
 
+module NicePartials::RenderingWithAutoContext
+  attr_reader :content
+
+  def render(options = {}, locals = {}, &block)
+    _content = content
+    _layout_for(@content = np) if block&.arity == 1 # Mimic standard `yield` by calling into `_layout_for` directly.
+    super
+  ensure
+    @content = _content
+  end
+end
+
 ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix
+ActionView::Base.prepend NicePartials::RenderingWithAutoContext

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -34,6 +34,10 @@ module NicePartials::RenderingWithAutoContext
   ensure
     @content = _content
   end
+
+  def p(*args)
+    args.empty? ? content : super
+  end
 end
 
 ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -2,6 +2,16 @@ module NicePartials
   class Partial
     delegate_missing_to :@view_context
 
+    #   <%= render "nice_partial" do |p| %>
+    #     <% p.content_for :title, "Yo" %>
+    #     This line is printed to the `output_buffer`.
+    #   <% end %>
+    #
+    # Then in the nice_partial:
+    #   <%= content.content_for :title %> # => "Yo"
+    #   <%= content.output_buffer %> # => "This line is printed to the `output_buffer`."
+    attr_accessor :output_buffer
+
     def initialize(view_context)
       @view_context = view_context
       @key = SecureRandom.uuid

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -33,5 +33,12 @@ module NicePartials
     def content_for?(name)
       @view_context.content_for?("#{name}_#{@key}".to_sym)
     end
+
+    def capture(block)
+      if block&.arity == 1
+        # Mimic standard `yield` by calling into `_layout_for` directly.
+        self.output_buffer = @view_context._layout_for(self, &block)
+      end
+    end
   end
 end

--- a/test/fixtures/_basic.html.erb
+++ b/test/fixtures/_basic.html.erb
@@ -1,1 +1,1 @@
-<%= content.yield :message %>
+<%= p.yield :message %>

--- a/test/fixtures/_basic.html.erb
+++ b/test/fixtures/_basic.html.erb
@@ -1,2 +1,1 @@
-<% yield p = np %>
-<%= p.yield :message %>
+<%= content.yield :message %>

--- a/test/fixtures/_basic.html.erb
+++ b/test/fixtures/_basic.html.erb
@@ -1,1 +1,1 @@
-<%= p.yield :message %>
+<%= _p.yield :message %>

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -1,12 +1,10 @@
-<% yield p = np %>
-
 <div class="card">
-  <%= p.yield :image %>
+  <%= content.yield :image %>
   <div class="card-body">
     <h5 class="card-title"><%= title %></h5>
-    <% if p.content_for? :body %>
+    <% if content.content_for? :body %>
       <p class="card-text">
-        <%= p.content_for :body %>
+        <%= content.content_for :body %>
       </p>
     <% end %>
   </div>

--- a/test/fixtures/_clobberer.html.erb
+++ b/test/fixtures/_clobberer.html.erb
@@ -1,0 +1,2 @@
+<% p "it's clobbering time" %>
+<%= p.yield :message %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -26,4 +26,12 @@ class RendererTest < NicePartials::Test
     assert_rendered "hello from nice partials"
     assert_equal "Some extra content", nice_partial.output_buffer
   end
+
+  test "doesn't clobber Kernel.p" do
+    assert_output "\"it's clobbering time\"\n" do
+      render("clobberer") { |p| p.content_for :message, "hello from nice partials" }
+    end
+
+    assert_rendered "hello from nice partials"
+  end
 end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -14,4 +14,16 @@ class RendererTest < NicePartials::Test
     assert_rendered "Lorem Ipsum"
     assert_rendered "https://example.com/image.jpg"
   end
+
+  test "output_buffer captures content not written via yield/content_for" do
+    nice_partial = nil
+    render "basic" do |p|
+      nice_partial = p
+      p.content_for :message, "hello from nice partials"
+      "Some extra content"
+    end
+
+    assert_rendered "hello from nice partials"
+    assert_equal "Some extra content", nice_partial.output_buffer
+  end
 end


### PR DESCRIPTION
In a template like this, we now infer that the block takes 1 parameter
and automatically yield a `np` composable content section:

```ruby
render "card" do |card|
  card.yield :title, t(".title")
end
```

The rendered "card" partial would previously need to be annotated with
`yield content = np` but that's no longer needed, and it can instead just
access the yielded Partial instance that's exposed in `content`:

```
content.content_for :title
```

Note: it was custom to do `yield p = np` previously, but I've chosen `content`
as slightly more descriptive now that we're automatic.

This doesn't break compatibility, but does perform an extra yield until
apps switch. We could put this behind a config flag.