### PR TITLE
Auto-capture render blocks and expose context specific _p

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -33,12 +33,5 @@ module NicePartials
     def content_for?(name)
       @view_context.content_for?("#{name}_#{@key}".to_sym)
     end
-
-    def capture(block)
-      if block&.arity == 1
-        # Mimic standard `yield` by calling into `_layout_for` directly.
-        self.output_buffer = @view_context._layout_for(self, &block)
-      end
-    end
   end
 end

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,9 +1,9 @@
-<%= render "card", title: "Some Title" do |p| %>
-  <% p.content_for :body do %>
+<%= render "card", title: "Some Title" do %>
+  <% _p.content_for :body do %>
     Lorem Ipsum
   <% end %>
 
-  <% p.content_for :image do %>
+  <% _p.content_for :image do %>
     <img src="https://example.com/image.jpg" />
   <% end %>
 <% end %>


### PR DESCRIPTION
This attempts expose a context specific `_p`, so the below would work and point to the right `_p` instance:

```ruby
# _card.html.erb
_p.content_for :title

# show.html.erb
render "card" do
  _p.content_for :title, t(".title")
end
```

To do this, we're attempting to always auto-capture a block that's passed to render like the `render "card" do` case, e.g. the card partial doesn't have to insert `yield _p`.