### PR TITLE
Remove `partial` shorthand `_p` and deprecate `p`

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -26,10 +26,9 @@ end
 
 module NicePartials::RenderingWithAutoContext
   attr_reader :partial
-  alias_method :_p, :partial
 
   def p(*args)
-    args.empty? ? _p : super
+    args.empty? ? partial : super
   end
 
   def render(options = {}, locals = {}, &block)

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -24,11 +24,19 @@ module NicePartials::RenderingWithLocalePrefix
   end
 end
 
+require "active_support/deprecation"
+NicePartials::DEPRECATOR = ActiveSupport::Deprecation.new("1.0", "nice_partials")
+
 module NicePartials::RenderingWithAutoContext
   attr_reader :partial
 
   def p(*args)
-    args.empty? ? partial : super
+    if args.empty?
+      NicePartials::DEPRECATOR.deprecation_warning :p, :partial # In-branch printing so we don't warn on legit `Kernel.p` calls.
+      partial
+    else
+      super # …we're really Kernel.p
+    end
   end
 
   def render(options = {}, locals = {}, &block)

--- a/test/fixtures/_clobberer.html.erb
+++ b/test/fixtures/_clobberer.html.erb
@@ -1,2 +1,3 @@
 <% p "it's clobbering time" %>
+<%# TODO: Remove this file once `p` has been removed post deprecation, but don't change it yet. %>
 <%= p.yield :message %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -34,4 +34,12 @@ class RendererTest < NicePartials::Test
 
     assert_rendered "hello from nice partials"
   end
+
+  test "deprecates top-level access through p method" do
+    assert_deprecated /p is deprecated and will be removed from nice_partials \d/, NicePartials::DEPRECATOR do
+      assert_output "\"it's clobbering time\"\n" do
+        render("clobberer") { |p| p.content_for :message, "hello from nice partials" }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #36

By default the deprecator logs to the console, put for ferreting errant `p` calls in CI, users could swap to raising:

```ruby
NicePartials::DEPRECATOR.behavior = :raise
```