### PR TITLE
Rename `Partial#output_buffer` to `Partial#yield`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+* Rename `p.output_buffer` to `p.yield` with no arguments
+
+### 0.1.7
+
 * Rely on `ActiveSupport.on_load :action_view`
 * Add support for Ruby 3.0
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -6,7 +6,7 @@ module NicePartials
 
     #   <%= render "nice_partial" do |p| %>
     #     <% p.content_for :title, "Yo" %>
-    #     This line is printed to the `output_buffer`.
+    #     This content can be accessed through calling `yield`.
     #   <% end %>
     #
     # Then in the nice_partial:
@@ -21,7 +21,7 @@ module NicePartials
 
     def yield(*arguments, &block)
       if arguments.empty?
-        raise "You can only use Nice Partial's yield method to retrieve the content of named content area blocks. If you're not trying to fetch the content of a named content area block, you don't need Nice Partials! You can just call the vanilla Rails `yield`."
+        output_buffer
       else
         content_for(*arguments, &block)
       end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -53,7 +53,7 @@ class RendererTest < NicePartials::Test
     end
 
     assert_rendered "hello from nice partials"
-    assert_equal "Some extra content", nice_partial.output_buffer
+    assert_equal "Some extra content", nice_partial.yield
   end
 
   test "doesn't clobber Kernel.p" do


### PR DESCRIPTION
Related to [bullet-train-co/nice_partials#29][]

When called without a `name` argument, treat `Partial#yield` as an
`output_buffer` reader. Along with that change, make `output_buffer` a
`Partial`-private attribute accessor.

[bullet-train-co/nice_partials#29]: https://github.com/bullet-train-co/nice_partials/issues/29#issuecomment-1173070462