### PR TITLE
Allow yielding arguments to `content_for` blocks

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -58,7 +58,7 @@ module NicePartials
     class Section
       def initialize(view_context)
         @view_context = view_context
-        @block = nil
+        @pending_content = nil
         @content = ActiveSupport::SafeBuffer.new
       end
 
@@ -66,25 +66,25 @@ module NicePartials
         if write_content_for(arguments.first, &block)
           nil
         else
-          capture_content_for(*arguments) if @block
+          capture_content_for(*arguments) if @pending_content
           @content.presence
         end
       end
 
       def content?
-        @block || @content.present?
+        @pending_content.present? || @content.present?
       end
 
       private
 
       def write_content_for(content = nil, &block)
-        @content << content.to_s if content && !@block
-        @block = block if block
+        @content << content.to_s if content && !@pending_content
+        @pending_content = block if block
       end
 
       def capture_content_for(*arguments)
-        @content << @view_context.capture(*arguments, &@block).to_s
-        @block = nil
+        @content << @view_context.capture(*arguments, &@pending_content).to_s
+        @pending_content = nil
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -78,8 +78,12 @@ module NicePartials
       private
 
       def write_content_for(content = nil, &block)
-        @content << content.to_s if content && !@pending_content
-        @pending_content = block if block
+        case
+        when content && !@pending_content
+          @content << content.to_s
+        when block
+          @pending_content = block
+        end
       end
 
       def capture_content_for(*arguments)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -62,24 +62,29 @@ module NicePartials
         @content = ActiveSupport::SafeBuffer.new
       end
 
-      def content_for(content = nil, *arguments, &block)
-        case
-        when block_given?
-          @block = block
-        when block = @block
-          @block = nil
-          @content << @view_context.capture(content, *arguments, &block).to_s
-          @content.presence
-        when content
-          @content << content.to_s
+      def content_for(*arguments, &block)
+        if write_content_for(arguments.first, &block)
           nil
         else
+          capture_content_for(*arguments) if @block
           @content.presence
         end
       end
 
       def content?
         @block || @content.present?
+      end
+
+      private
+
+      def write_content_for(content = nil, &block)
+        @content << content.to_s if content && !@block
+        @block = block if block
+      end
+
+      def capture_content_for(*arguments)
+        @content << @view_context.capture(*arguments, &@block).to_s
+        @block = nil
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -16,19 +16,35 @@ module NicePartials
       @view_context = view_context
     end
 
-    def yield(name = nil)
-      raise "You can only use Nice Partial's yield method to retrieve the content of named content area blocks. If you're not trying to fetch the content of a named content area block, you don't need Nice Partials! You can just call the vanilla Rails `yield`." unless name
-      content_for(name)
+    def yield(*arguments, &block)
+      if arguments.empty?
+        raise "You can only use Nice Partial's yield method to retrieve the content of named content area blocks. If you're not trying to fetch the content of a named content area block, you don't need Nice Partials! You can just call the vanilla Rails `yield`."
+      else
+        content_for(*arguments, &block)
+      end
     end
 
     def helpers(&block)
       class_eval &block
     end
 
-    def content_for(name, content = nil, &block)
-      content = @view_context.capture(&block) if block
-
-      if content
+    # Similar to Rails' built-in `content_for` except it defers any block execution
+    # and lets you pass arguments into it, like so:
+    #
+    #   # Here we store a block with some eventual content…
+    #   <% partial.content_for :title do |tag|
+    #     <%= tag.h1 %>
+    #   <% end %>
+    #
+    #  # …which is then invoked with some predefined options later.
+    #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
+    def content_for(name, content = nil, *arguments, &block)
+      case
+      when block_given?
+        defer_content_for(name, block)
+      when deferred_content = deferred_content_for(name, content, *arguments)
+        contents[name] = deferred_content.to_s
+      when content
         contents[name] << content.to_s
         nil
       else
@@ -37,7 +53,7 @@ module NicePartials
     end
 
     def content_for?(name)
-      contents[name].present?
+      deferred_contents.key?(name) || contents[name].present?
     end
 
     def capture(block)
@@ -51,6 +67,20 @@ module NicePartials
 
     def contents
       @contents ||= Hash.new { |h, k| h[k] = ActiveSupport::SafeBuffer.new }
+    end
+
+    def defer_content_for(name, block)
+      deferred_contents[name] = block
+    end
+
+    def deferred_content_for(name, *arguments)
+      if block = deferred_contents.delete(name)
+        @view_context.capture(*arguments, &block)
+      end
+    end
+
+    def deferred_contents
+      @deferred_contents ||= {}
     end
   end
 end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -67,27 +67,31 @@ module NicePartials
           nil
         else
           capture_content_for(*arguments) if @pending_content
-          @content.presence
+          @content
         end
       end
 
       def content?
-        @pending_content.present? || @content.present?
+        @pending_content || @content
       end
 
       private
 
       def write_content_for(content = nil, &block)
         if content && !@pending_content
-          @content << content.to_s
+          concat content
         else
           @pending_content = block if block
         end
       end
 
       def capture_content_for(*arguments)
-        @content << @view_context.capture(*arguments, &@pending_content).to_s
+        concat @view_context.capture(*arguments, &@pending_content)
         @pending_content = nil
+      end
+
+      def concat(string)
+        @content << string.to_s if string.present?
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,5 +1,7 @@
 module NicePartials
   class Partial
+    autoload :Section, "nice_partials/partial/section"
+
     delegate_missing_to :@view_context
 
     #   <%= render "nice_partial" do |p| %>
@@ -51,52 +53,6 @@ module NicePartials
       if block&.arity == 1
         # Mimic standard `yield` by calling into `_layout_for` directly.
         self.output_buffer = @view_context._layout_for(self, &block)
-      end
-    end
-
-    private
-
-    class Section
-      def initialize(view_context)
-        @view_context = view_context
-        @content = @pending_content = nil
-      end
-
-      def content_for(*arguments, &block)
-        if write_content_for(arguments.first, &block)
-          nil
-        else
-          capture_content_for(*arguments) if pending?
-          @content
-        end
-      end
-
-      def content?
-        pending? || @content
-      end
-
-      private
-
-      def write_content_for(content = nil, &block)
-        if content && !pending?
-          concat content
-        else
-          @pending_content = block if block
-        end
-      end
-
-      def capture_content_for(*arguments)
-        concat @view_context.capture(*arguments, &@pending_content)
-        @pending_content = nil
-      end
-
-      def concat(string)
-        @content ||= ActiveSupport::SafeBuffer.new
-        @content << string.to_s if string.present?
-      end
-
-      def pending?
-        @pending_content
       end
     end
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -78,11 +78,10 @@ module NicePartials
       private
 
       def write_content_for(content = nil, &block)
-        case
-        when content && !@pending_content
+        if content && !@pending_content
           @content << content.to_s
-        when block
-          @pending_content = block
+        else
+          @pending_content = block if block
         end
       end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -58,8 +58,7 @@ module NicePartials
     class Section
       def initialize(view_context)
         @view_context = view_context
-        @pending_content = nil
-        @content = ActiveSupport::SafeBuffer.new
+        @content = @pending_content = nil
       end
 
       def content_for(*arguments, &block)
@@ -91,6 +90,7 @@ module NicePartials
       end
 
       def concat(string)
+        @content ||= ActiveSupport::SafeBuffer.new
         @content << string.to_s if string.present?
       end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -39,20 +39,7 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def content_for(name, content = nil, *arguments, &block)
-      section = contents[name]
-
-      case
-      when block_given?
-        section.block = block
-      when section.block?
-        section.deferred_content_for(content, *arguments)
-        section.content.presence
-      when content
-        section << content
-        nil
-      else
-        section.content.presence
-      end
+      contents[name].content_for(content, *arguments, &block)
     end
 
     def content_for?(name)
@@ -76,6 +63,23 @@ module NicePartials
       def initialize(view_context)
         @view_context = view_context
         @content = ActiveSupport::SafeBuffer.new
+      end
+
+      def content_for(*arguments, &block)
+        _content = arguments.first
+
+        case
+        when block_given?
+          self.block = block
+        when block?
+          deferred_content_for(_content, *arguments)
+          content.presence
+        when _content
+          self << _content
+          nil
+        else
+          content.presence
+        end
       end
 
       def deferred_content_for(*arguments)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -66,19 +66,19 @@ module NicePartials
         if write_content_for(arguments.first, &block)
           nil
         else
-          capture_content_for(*arguments) if @pending_content
+          capture_content_for(*arguments) if pending?
           @content
         end
       end
 
       def content?
-        @pending_content || @content
+        pending? || @content
       end
 
       private
 
       def write_content_for(content = nil, &block)
-        if content && !@pending_content
+        if content && !pending?
           concat content
         else
           @pending_content = block if block
@@ -92,6 +92,10 @@ module NicePartials
 
       def concat(string)
         @content << string.to_s if string.present?
+      end
+
+      def pending?
+        @pending_content
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -14,6 +14,7 @@ module NicePartials
 
     def initialize(view_context)
       @view_context = view_context
+      @contents = Hash.new { |h, k| h[k] = Section.new(@view_context) }
     end
 
     def yield(*arguments, &block)
@@ -39,11 +40,11 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def content_for(name, content = nil, *arguments, &block)
-      contents[name].content_for(content, *arguments, &block)
+      @contents[name].content_for(content, *arguments, &block)
     end
 
     def content_for?(name)
-      contents[name].content?
+      @contents[name].content?
     end
 
     def capture(block)
@@ -97,10 +98,6 @@ module NicePartials
       def pending?
         @pending_content
       end
-    end
-
-    def contents
-      @contents ||= Hash.new { |h, k| h[k] = Section.new(@view_context) }
     end
   end
 end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -56,38 +56,30 @@ module NicePartials
     private
 
     class Section
-      attr_reader :content
-
       def initialize(view_context)
         @view_context = view_context
         @block = nil
         @content = ActiveSupport::SafeBuffer.new
       end
 
-      def content_for(*arguments, &block)
-        _content = arguments.first
-
+      def content_for(content = nil, *arguments, &block)
         case
         when block_given?
           @block = block
         when @block
-          self << @view_context.capture(*arguments, &@block)
+          @content << @view_context.capture(*arguments, &@block).to_s
           @block = nil
-          content.presence
-        when _content
-          self << _content
+          @content.presence
+        when content
+          @content << content.to_s
           nil
         else
-          content.presence
+          @content.presence
         end
       end
 
-      def <<(content)
-        @content << content.to_s
-      end
-
       def content?
-        @block || content.present?
+        @block || @content.present?
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -66,9 +66,9 @@ module NicePartials
         case
         when block_given?
           @block = block
-        when @block
-          @content << @view_context.capture(*arguments, &@block).to_s
+        when block = @block
           @block = nil
+          @content << @view_context.capture(content, *arguments, &block).to_s
           @content.presence
         when content
           @content << content.to_s

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,0 +1,43 @@
+class NicePartials::Partial::Section
+  def initialize(view_context)
+    @view_context = view_context
+    @content = @pending_content = nil
+  end
+
+  def content_for(*arguments, &block)
+    if write_content_for(arguments.first, &block)
+      nil
+    else
+      capture_content_for(*arguments) if pending?
+      @content
+    end
+  end
+
+  def content?
+    pending? || @content
+  end
+
+  private
+
+  def write_content_for(content = nil, &block)
+    if content && !pending?
+      concat content
+    else
+      @pending_content = block if block
+    end
+  end
+
+  def capture_content_for(*arguments)
+    concat @view_context.capture(*arguments, &@pending_content)
+    @pending_content = nil
+  end
+
+  def concat(string)
+    @content ||= ActiveSupport::SafeBuffer.new
+    @content << string.to_s if string.present?
+  end
+
+  def pending?
+    @pending_content
+  end
+end

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -4,7 +4,7 @@
     <h5 class="card-title"><%= title %></h5>
     <% if partial.content_for? :body %>
       <p class="card-text">
-        <%= partial.content_for :body %>
+        <%= partial.content_for :body, tag.with_options(class: "text-bold") %>
       </p>
     <% end %>
   </div>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,6 +1,6 @@
 <%= render "card", title: "Some Title" do |p| %>
-  <% p.content_for :body do %>
-    Lorem Ipsum
+  <% p.content_for :body do |tag| %>
+    <%= tag.p "Lorem Ipsum" %>
   <% end %>
 
   <% p.content_for :image do %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -11,7 +11,7 @@ class RendererTest < NicePartials::Test
     render(template: "card_test")
 
     assert_rendered "Some Title"
-    assert_rendered "Lorem Ipsum"
+    assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
     assert_rendered "https://example.com/image.jpg"
   end
 


### PR DESCRIPTION
Nice Partial's `content_for` is similar to Rails' `content_for`, except
now that we have control of the backing storage we can change the
implementation to allow new features.

Here we deferring block execution so we can yield arguments into it:

```ruby
<% partial.content_for :title do |tag|
  <%= tag.h1 %>
<% end %>

<%= partial.content_for :title, tag.with_options(class: "text-bold") %>
```

cc @seanpdoyle 