### PR TITLE
Perform a disappearing act with Nice Partials 🪄

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -60,17 +60,19 @@ module NicePartials::RenderingWithAutoContext
   end
 end
 
-ActionView::Template.prepend Module.new {
+module NicePartials::CapturingYieldDetection
+  # Matches plain yields that'll end up calling `capture`:
+  #   <%= yield %>
+  #   <%= yield something_else %>
+  #
+  # Doesn't match obfuscated `content_for` invocations:
+  #   <%= yield :message %>
   def has_capturing_yield?
-    # Matches plain yields that'll end up calling `capture`:
-    #   <%= yield %>
-    #   <%= yield something_else %>
-    #
-    # Doesn't match obfuscated `content_for` invocations:
-    #   <%= yield :message %>
     source.match? /\byield[\(? ]+[^:]/
   end
-}
+end
+
+ActionView::Template.include NicePartials::CapturingYieldDetection
 
 ActionView::Base.prepend NicePartials::RenderingWithLocalePrefix
 ActionView::Base.prepend NicePartials::RenderingWithAutoContext

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -28,7 +28,9 @@ require "active_support/deprecation"
 NicePartials::DEPRECATOR = ActiveSupport::Deprecation.new("1.0", "nice_partials")
 
 module NicePartials::RenderingWithAutoContext
-  attr_reader :partial
+  def partial
+    @partial ||= nice_partial
+  end
   delegate :content_for?, :content_for, to: :partial
 
   def p(*args)
@@ -41,7 +43,7 @@ module NicePartials::RenderingWithAutoContext
   end
 
   def render(options = {}, locals = {}, &block)
-    _partial, @partial = partial, nice_partial
+    _partial = @partial
     super
   ensure
     @partial = _partial

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -42,7 +42,7 @@ module NicePartials::RenderingWithAutoContext
 
   def render(options = {}, locals = {}, &block)
     _partial, @partial = partial, nice_partial
-    _layout_for(&block) # if !@current_template || @current_template.manual_yield?
+    _layout_for(&block) # if !@current_template || @current_template.has_capturing_yield?
     super
   ensure
     @partial = _partial
@@ -61,14 +61,14 @@ module NicePartials::RenderingWithAutoContext
 end
 
 ActionView::Template.prepend Module.new {
-  def manual_yield?
+  def has_capturing_yield?
     # Matches plain yields that'll end up calling `capture`:
     #   <%= yield %>
     #   <%= yield something_else %>
     #
     # Doesn't match obfuscated `content_for` invocations:
     #   <%= yield :message %>
-    source.match? /\byield[\(? ]+\:/
+    source.match? /\byield[\(? ]+[^:]/
   end
 }
 

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -42,7 +42,6 @@ module NicePartials::RenderingWithAutoContext
 
   def render(options = {}, locals = {}, &block)
     _partial, @partial = partial, nice_partial
-    _layout_for(&block) # if !@current_template || @current_template.has_capturing_yield?
     super
   ensure
     @partial = _partial
@@ -59,6 +58,15 @@ module NicePartials::RenderingWithAutoContext
     end
   end
 end
+
+module NicePartials::PartialRendering
+  def render_partial_template(view, locals, template, layout, block)
+    view._layout_for(&block) unless template.has_capturing_yield?
+    super
+  end
+end
+
+ActionView::PartialRenderer.prepend NicePartials::PartialRendering
 
 module NicePartials::CapturingYieldDetection
   # Matches plain yields that'll end up calling `capture`:

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -54,6 +54,7 @@ module NicePartials::RenderingWithAutoContext
     if arguments.first.is_a?(Symbol)
       partial.content_for(*arguments)
     elsif block
+      # TODO: Check if the block condition is enough to not break `yield` with no arguments calls.
       partial.output_buffer ||= capture(*arguments, partial, &block)
     end
   end

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -79,7 +79,11 @@ module NicePartials::CapturingYieldDetection
   # Doesn't match obfuscated `content_for` invocations:
   #   <%= yield :message %>
   def has_capturing_yield?
-    source.match? /\byield[\(? ]+[^:]/
+    if defined?(@has_capturing_yield)
+      @has_capturing_yield
+    else
+      @has_capturing_yield = source.match? /\byield[\(? ]+[^:]/
+    end
   end
 end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -48,12 +48,5 @@ module NicePartials
     def content_for?(name)
       @contents[name].content?
     end
-
-    def capture(block)
-      if block&.arity == 1
-        # Mimic standard `yield` by calling into `_layout_for` directly.
-        self.output_buffer = @view_context._layout_for(self, &block)
-      end
-    end
   end
 end

--- a/test/fixtures/_basic.html.erb
+++ b/test/fixtures/_basic.html.erb
@@ -1,1 +1,1 @@
-<%= partial.yield :message %>
+<%= yield :message %>

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -1,10 +1,10 @@
 <div class="card">
-  <%= partial.yield :image %>
+  <%= yield :image %>
   <div class="card-body">
     <h5 class="card-title"><%= title %></h5>
-    <% if partial.content_for? :body %>
+    <% if content_for? :body %>
       <p class="card-text">
-        <%= partial.content_for :body, tag.with_options(class: "text-bold") %>
+        <%= content_for :body, tag.with_options(class: "text-bold") %>
       </p>
     <% end %>
   </div>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,9 +1,9 @@
-<%= render "card", title: "Some Title" do |p| %>
-  <% p.content_for :body do |tag| %>
+<%= render "card", title: "Some Title" do %>
+  <% content_for :body do |tag| %>
     <%= tag.p "Lorem Ipsum" %>
   <% end %>
 
-  <% p.content_for :image do %>
+  <% content_for :image do %>
     <img src="https://example.com/image.jpg" />
   <% end %>
 <% end %>

--- a/test/fixtures/translations/_nice_partials_translated.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated.html.erb
@@ -1,3 +1,3 @@
-<%= render("basic") do |partial| %>
-  <%= partial.content_for :message, t(".message") %>
+<%= render("basic") do %>
+  <%= content_for :message, t(".message") %>
 <% end %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RendererTest < NicePartials::Test
   test "render basic nice partial" do
-    render("basic") { |p| p.content_for :message, "hello from nice partials" }
+    render("basic") { |p| p.yield :message, "hello from nice partials" }
 
     assert_rendered "hello from nice partials"
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,8 @@ require "action_view/test_case"
 
 require "nice_partials"
 
+require "debug"
+
 class NicePartials::Test < ActionView::TestCase
   TestController.view_paths << "test/fixtures"
 


### PR DESCRIPTION
By overriding `_layout_for` we can essentially let users just write
plain ol' `yield`s like they're used to without worrying about Nice Partials
at all.

Still a work in progress and I want to tighten up the `manual_yield?` detection too.