### PR TITLE
Fix accessing `partial` before rendering leaks state

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -46,7 +46,7 @@ module NicePartials::RenderingWithAutoContext
   end
 
   def render(options = {}, locals = {}, &block)
-    _partial = @partial
+    _partial, @partial = @partial, nil
     super
   ensure
     @partial = _partial

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -45,7 +45,7 @@ module NicePartials::RenderingWithAutoContext
     end
   end
 
-  def render(options = {}, locals = {}, &block)
+  def render(*)
     _partial, @partial = @partial, nil
     super
   ensure

--- a/test/fixtures/_partial_accessed_in_outer_context.html.erb
+++ b/test/fixtures/_partial_accessed_in_outer_context.html.erb
@@ -1,0 +1,12 @@
+<%# Access the partial in the outer context before renders %>
+<% partial %>
+
+<%= render "basic" do |partial| %>
+  <% partial.content_for :message, "hello" %>
+<% end %>
+
+<%= render "basic" do |partial| %>
+  <% partial.content_for :message, "goodbye" %>
+<% end %>
+
+<span><%= partial.content_for :message %></span>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -15,6 +15,15 @@ class RendererTest < NicePartials::Test
     assert_rendered "https://example.com/image.jpg"
   end
 
+  test "accessing partial in outer context won't leak state to inner render" do
+    render "partial_accessed_in_outer_context"
+
+    assert_rendered "hello"
+    assert_rendered "goodbye"
+    assert_rendered "<span></span>"
+    assert_not_includes rendered, "hellogoodbye"
+  end
+
   test "explicit yield without any arguments auto-captures passed block" do
     render "yields/plain" do |partial, auto_capture_shouldnt_pass_extra_argument|
       assert_kind_of NicePartials::Partial, partial


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/nice_partials/issues/46

If you call `partial` and then `render` with partials that also use
`partial`, they'll inherit the outer `NicePartials::Partial` instance.

In effect, if you render partials that use the same named buffers
they'll concat to each other instead of being separated.

```ruby
partial
render("card") { _1.content_for :title, "one" } # :title is "one"
render("card") { _1.content_for :title, "two" } # :title is "onetwo"
partial.content_for :title # => "onetwo"
```

This commit ensures we clear any `partial` on a new render call, so state
won't leak.