### PR TITLE
Use load hooks for monkey_patch loading

### DIFF
--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "nice_partials/version"
-require_relative "nice_partials/helper"
-require_relative "nice_partials/monkey_patch"
 
 module NicePartials
   def self.locale_prefix_from(lookup_context, block)
@@ -14,5 +12,8 @@ module NicePartials
 end
 
 ActiveSupport.on_load :action_view do
+  require_relative "nice_partials/monkey_patch"
+
+  require_relative "nice_partials/helper"
   include NicePartials::Helper
 end


### PR DESCRIPTION
`ActiveSupport.on_load(:action_view)` is technically how we're supposed
to extend ActionView::Base and other Action View classes, but we weren't
doing that for our monkey patches.

We could add a `ActiveSupport.on_load(:action_view)` load hook for each
extension, but it feels cleaner to let the top level file handle that
set up.

This then also moves the helper require to the same place for parity.