### PR TITLE
Allow outer partial access when capturing

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,6 +1,7 @@
 module NicePartials
   class Partial
     autoload :Section, "nice_partials/partial/section"
+    autoload :Stack, "nice_partials/partial/stack"
 
     delegate_missing_to :@view_context
 

--- a/lib/nice_partials/partial/stack.rb
+++ b/lib/nice_partials/partial/stack.rb
@@ -1,0 +1,19 @@
+class NicePartials::Partial::Stack
+  def initialize
+    @partials = []
+    reset_locator
+  end
+  delegate :prepend, :shift, :first, to: :@partials
+
+  def partial
+    @partials.public_send @locator
+  end
+
+  def locate_previous
+    @locator = :second
+  end
+
+  def reset_locator
+    @locator = :first
+  end
+end

--- a/test/fixtures/_partial_accessed_in_outer_context.html.erb
+++ b/test/fixtures/_partial_accessed_in_outer_context.html.erb
@@ -1,12 +1,11 @@
-<%# Access the partial in the outer context before renders %>
-<% partial %>
+<% partial.content_for :original_message, "hello" %>
 
-<%= render "basic" do |partial| %>
-  <% partial.content_for :message, "hello" %>
+<%= render "basic" do |cp| %>
+  <% cp.content_for :message, partial.content_for(:original_message) %>
 <% end %>
 
-<%= render "basic" do |partial| %>
-  <% partial.content_for :message, "goodbye" %>
+<%= render "basic" do |cp| %>
+  <% cp.content_for :message, "goodbye" %>
 <% end %>
 
 <span><%= partial.content_for :message %></span>


### PR DESCRIPTION
Due to rendering happening in the same `ActionView::Base` instance,
the `@partial` instance variable was effectively shared between all
render calls.

As such, doing this:

```ruby
render "card" do |cp|
  cp.content_for :title, partial.content_for(:title)
end
```

…wouldn't work because `partial` would point to the inner `cp`.

This commit fixes it so we no longer shadow the partial method.

Fixes https://github.com/bullet-train-co/nice_partials/issues/38