### PR TITLE
Add `content_from` to let partials relay contents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - *wait_for_docker
       - run:
           name: Run unit tests
-          command: bundle exec rails test
+          command: bin/test
 
   'Local Standard Ruby':
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,22 @@
   <% partial.title "content", class: "post-title" %> # Adding some content and options…
   <% partial.title.h2 %> # => <h2 class="post-title">content</h2>
   <% partial.title.h2 "more" %> # => <h2 class="post-title">contentmore</h2>
+
+* Add `Partial#content_from`
+
+  `content_from` lets a partial extract contents from another partial.
+  Additionally, contents can be renamed by passing a hash:
+
+  ```erb
+  <% partial.title "Hello there" %>
+  <% partial.byline "Somebody" %>
+
+  <%= render "shared/title" do |cp| %>
+    # Here the inner partial `cp` accesses the outer partial through `partial`
+    # extracting the `title` and `byline` contents.
+    # `byline` is renamed to `name` in `cp`.
+    <% cp.content_from partial, :title, byline: :name %>
+  <% end %>
   ```
 
 * Remove need to insert `<% yield p = np %>` in partials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
   <% partial.title? %> # => true
   ```
 
+  Note, `title?` uses `present?` under the hood so rendering could also be made conditional with:
+
+  ```erb
+  <% partial.title if partial.title? %> # Instead of this…
+  <% partial.title.presence %> # …you can do this
+  ```
+
   #### Passing procs or components
 
   Procs and objects that implement render_in, like ViewComponents, can also be appended as content:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 ## CHANGELOG
 
+* Let partials respond to named content sections
+
+  ```erb
+  <% partial.content_for :title, "Title content" %> # Before
+  <% partial.title "Title content" %> # After
+
+  # Which can then be output
+  <% partial.title %> # => "Title content"
+  <% partial.title? %> # => true
+  ```
+
+  #### Passing procs or components
+
+  Procs and objects that implement render_in, like ViewComponents, can also be appended as content:
+
+  ```erb
+  <% partial.title { "some content" } %>
+  <% partial.title TitleComponent.new(Current.user) %>
+  ```
+
+  #### Capturing `options`
+
+  Options can also be captured and output:
+
+  ```erb
+  <% partial.title class: "text-m4" %> # partial.title.options # => { class: "text-m4" }
+
+  # When output `to_s` is called and options automatically pipe through `tag.attributes`:
+  <h1 <% partial.title.options %>> # => <h1 class="post-title">
+  ```
+
+  #### Proxying to the view context and appending content
+
+  A content section appends to its content when calling any view context method on it, e.g.:
+
+  ```erb
+  <% partial.title.render "title", user: %>
+  <% partial.title.link_to @document.name, @document %>
+  <% partial.title.t ".title" %>
+  ```
+
+  #### Building elements with `tag` proxy
+
+  These `tag` calls let you generate elements based on the stored content and options:
+
+  ```erb
+  <% partial.title "content", class: "post-title" %> # Adding some content and options…
+  <% partial.title.h2 %> # => <h2 class="post-title">content</h2>
+  <% partial.title.h2 "more" %> # => <h2 class="post-title">contentmore</h2>
+  ```
+
 * Remove need to insert `<% yield p = np %>` in partials.
 
   Nice Partials now automatically captures blocks passed to `render`.

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 gem "minitest"
 gem "rake"
 gem "irb"
+
+# gem "attributes_and_token_lists", github: "seanpdoyle/attributes_and_token_lists"

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,8 @@ gem "minitest"
 gem "rake"
 gem "irb"
 
+gem "view_component"
+gem "rails"
+gem "sqlite3"
+
 # gem "attributes_and_token_lists", github: "seanpdoyle/attributes_and_token_lists"

--- a/Rakefile
+++ b/Rakefile
@@ -26,12 +26,3 @@ desc "#{gemspec.name} | IRB"
 task :irb do
   sh "irb -I ./lib -r #{gemspec.name.gsub '-','/'}"
 end
-
-# # #
-# Run specs
-
-desc "#{gemspec.name} | Test"
-task :test do
-  sh "for file in test/{**/,}*_test.rb; do ruby -Ilib:test $file; done"
-end
-task default: :test

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+$: << File.expand_path("../test", __dir__)
+
+require "bundler/setup"
+require "rails/plugin/test"

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -3,6 +3,9 @@
 require_relative "nice_partials/version"
 
 module NicePartials
+  singleton_class.attr_accessor :options_processor
+  self.options_processor = ->(options, new_options) { options.merge! new_options }
+
   def self.locale_prefix_from(lookup_context, block)
     root_paths = lookup_context.view_paths.map(&:path)
     partial_location = block.source_location.first.dup

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -3,8 +3,16 @@
 require_relative "nice_partials/version"
 
 module NicePartials
-  singleton_class.attr_accessor :options_class
-  self.options_class = Hash
+  class Options < Hash
+    attr_accessor :tag
+
+    def to_s
+      @tag.attributes(self)
+    end
+  end
+
+  singleton_class.attr_accessor :new_options
+  self.new_options = -> view_context { Options.new.tap { _1.tag = view_context.tag } }
 
   def self.locale_prefix_from(lookup_context, block)
     root_paths = lookup_context.view_paths.map(&:path)

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -2,6 +2,12 @@
 
 require_relative "nice_partials/version"
 
+begin
+  gem "attributes_and_token_lists"
+  require "attributes_and_token_lists/attributes"
+rescue LoadError
+end
+
 module NicePartials
   class Options < Hash
     attr_accessor :tag
@@ -12,7 +18,12 @@ module NicePartials
   end
 
   singleton_class.attr_accessor :new_options
-  self.new_options = -> view_context { Options.new.tap { _1.tag = view_context.tag } }
+  self.new_options =
+    if defined?(AttributesAndTokenLists::Attributes)
+      -> view_context { AttributesAndTokenLists::Attributes.new(view_context.tag, view_context) }
+    else
+      -> view_context { Options.new.tap { _1.tag = view_context.tag } }
+    end
 
   def self.locale_prefix_from(lookup_context, block)
     root_paths = lookup_context.view_paths.map(&:path)

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -3,8 +3,8 @@
 require_relative "nice_partials/version"
 
 module NicePartials
-  singleton_class.attr_accessor :options_processor
-  self.options_processor = ->(options, new_options) { options.merge! new_options }
+  singleton_class.attr_accessor :options_class
+  self.options_class = Hash
 
   def self.locale_prefix_from(lookup_context, block)
     root_paths = lookup_context.view_paths.map(&:path)

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -5,6 +5,9 @@ require_relative "nice_partials/version"
 begin
   gem "attributes_and_token_lists"
   require "attributes_and_token_lists/attributes"
+  require "attributes_and_token_lists/attribute_merger"
+  require "attributes_and_token_lists/tag_builder"
+  require "attributes_and_token_lists/token_list"
 rescue LoadError
 end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -42,6 +42,14 @@ module NicePartials
     #
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
+    def section(name, content = nil)
+      set_named_section(name).content_for(content)
+    end
+
+    def section?(name)
+      @sections&.dig(name)&.content?
+    end
+
     def content_for(name, content = nil, &block)
       set_named_content(name).content_for(content, &block)
     end
@@ -55,6 +63,10 @@ module NicePartials
     end
 
     private
+
+    def set_named_section(name)
+      @sections ||= {} and @sections[name] ||= Section.new(@view_context)
+    end
 
     def set_named_content(name)
       @contents ||= {} and @contents[name] ||= Content.new(@view_context)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -36,12 +36,10 @@ module NicePartials
     # and lets you pass arguments into it, like so:
     #
     #   # Here we store a block with some eventual content…
-    #   <% partial.content_for :title do |tag|
-    #     <%= tag.h1 %>
-    #   <% end %>
+    #   <% partial.title.store(&:h1) %>
     #
-    #  # …which is then invoked with some predefined options later.
-    #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
+    #  # …which we can then yield into with some predefined options later.
+    #  <%= partial.title.yield tag.with_options(class: "text-bold") %>
     def section(name, content = nil, &block)
       section_from(name).then { _1.write(content, &block) ? nil : _1 }
     end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -1,5 +1,6 @@
 module NicePartials
   class Partial
+    autoload :Content, "nice_partials/partial/content"
     autoload :Section, "nice_partials/partial/section"
     autoload :Stack, "nice_partials/partial/stack"
 
@@ -17,7 +18,7 @@ module NicePartials
 
     def initialize(view_context)
       @view_context = view_context
-      @contents = Hash.new { |h, k| h[k] = Section.new(@view_context) }
+      @contents = Hash.new { |h, k| h[k] = Content.new(@view_context) }
     end
 
     def yield(*arguments, &block)
@@ -42,8 +43,8 @@ module NicePartials
     #
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
-    def content_for(name, content = nil, *arguments, &block)
-      @contents[name].content_for(content, *arguments, &block)
+    def content_for(name, content = nil, &block)
+      @contents[name].content_for(content, &block)
     end
 
     def content_for?(name)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -76,8 +76,7 @@ module NicePartials
       if @view_context.respond_to?(meth)
         @view_context.public_send(meth, *arguments, **keywords, &block)
       else
-        define_accessor(meth)
-        public_send(meth)
+        define_accessor meth and public_send meth
       end
     end
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -50,7 +50,6 @@ module NicePartials
     #   <%= partial.name %> # => "Somebody"
     def content_from(partial, *names, **renames)
       names.chain(renames).each { |key, new_key = key| public_send new_key, partial.public_send(key).to_s }
-      nil
     end
 
     # Similar to Rails' built-in `content_for` except it defers any block execution

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -43,7 +43,7 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def section(name, content = nil, &block)
-      set_named_section(name).content_for(content, &block)
+      set_named_section(name).process(content, block)
     end
 
     def section?(name)
@@ -51,7 +51,7 @@ module NicePartials
     end
 
     def content_for(name, content = nil, &block)
-      set_named_content(name).content_for(content, &block)
+      set_named_content(name).process(content, block)
     end
 
     def content_for?(name)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -45,18 +45,12 @@ module NicePartials
     def section(name, content = nil, &block)
       set_named_section(name).process(content, block)
     end
+    alias content_for section
 
     def section?(name)
       @sections&.dig(name).present?
     end
-
-    def content_for(name, content = nil, &block)
-      set_named_content(name).process(content, block)
-    end
-
-    def content_for?(name)
-      @contents&.dig(name).present?
-    end
+    alias content_for? section?
 
     def capture(*arguments, &block)
       self.output_buffer = @view_context.capture(*arguments, self, &block)
@@ -66,10 +60,6 @@ module NicePartials
 
     def set_named_section(name)
       @sections ||= {} and @sections[name] ||= Section.new(@view_context)
-    end
-
-    def set_named_content(name)
-      @contents ||= {} and @contents[name] ||= Content.new(@view_context)
     end
 
     def method_missing(meth, *arguments, **keywords, &block)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -18,7 +18,6 @@ module NicePartials
 
     def initialize(view_context)
       @view_context = view_context
-      @contents = Hash.new { |h, k| h[k] = Content.new(@view_context) }
     end
 
     def yield(*arguments, &block)
@@ -44,15 +43,21 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def content_for(name, content = nil, &block)
-      @contents[name].content_for(content, &block)
+      set_named_content(name).content_for(content, &block)
     end
 
     def content_for?(name)
-      @contents[name].content?
+      @contents&.dig(name)&.content?
     end
 
     def capture(*arguments, &block)
       self.output_buffer = @view_context.capture(*arguments, self, &block)
+    end
+
+    private
+
+    def set_named_content(name)
+      @contents ||= {} and @contents[name] ||= Content.new(@view_context)
     end
   end
 end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -43,7 +43,7 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def section(name, content = nil, &block)
-      section_from(name).process(content, block)
+      section_from(name).then { _1.write(content, &block) ? nil : _1 }
     end
     alias content_for section
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -43,12 +43,15 @@ module NicePartials
     def section(name, content = nil, **options, &block)
       section_from(name).then { _1.write?(content, **options, &block) ? nil : _1 }
     end
-    alias content_for section
 
     def section?(name)
       @sections&.dig(name).present?
     end
     alias content_for? section?
+
+    def content_for(...)
+      section(...).to_s
+    end
 
     def capture(*arguments, &block)
       self.output_buffer = @view_context.capture(*arguments, self, &block)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -42,8 +42,8 @@ module NicePartials
     #
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
-    def section(name, content = nil)
-      set_named_section(name).content_for(content)
+    def section(name, content = nil, &block)
+      set_named_section(name).content_for(content, &block)
     end
 
     def section?(name)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -64,13 +64,13 @@ module NicePartials
       if @view_context.respond_to?(meth)
         @view_context.public_send(meth, *arguments, **keywords, &block)
       else
-        define_accessor meth and public_send meth
+        define_accessor meth and public_send(meth, *arguments, **keywords, &block)
       end
     end
 
     def define_accessor(name)
       name = name.to_s.chomp("?").to_sym
-      self.class.define_method(name) { section_from(name) }
+      self.class.define_method(name) { |content = nil, &block| section(name, content, &block) }
       self.class.define_method("#{name}?") { section?(name) }
     end
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -41,7 +41,7 @@ module NicePartials
     #  # …which we can then yield into with some predefined options later.
     #  <%= partial.title.yield tag.with_options(class: "text-bold") %>
     def section(name, content = nil, **options, &block)
-      section_from(name).then { _1.write(content, **options, &block) ? nil : _1 }
+      section_from(name).then { _1.write?(content, **options, &block) ? nil : _1 }
     end
     alias content_for section
 

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -47,7 +47,7 @@ module NicePartials
     end
 
     def section?(name)
-      @sections&.dig(name)&.content?
+      @sections&.dig(name).present?
     end
 
     def content_for(name, content = nil, &block)
@@ -55,7 +55,7 @@ module NicePartials
     end
 
     def content_for?(name)
-      @contents&.dig(name)&.content?
+      @contents&.dig(name).present?
     end
 
     def capture(*arguments, &block)

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -71,5 +71,20 @@ module NicePartials
     def set_named_content(name)
       @contents ||= {} and @contents[name] ||= Content.new(@view_context)
     end
+
+    def method_missing(meth, *arguments, **keywords, &block)
+      if @view_context.respond_to?(meth)
+        @view_context.public_send(meth, *arguments, **keywords, &block)
+      else
+        define_accessor(meth)
+        public_send(meth)
+      end
+    end
+
+    def define_accessor(name)
+      name = name.to_s.chomp("?").to_sym
+      self.class.define_method(name) { set_named_section(name) }
+      self.class.define_method("#{name}?") { section?(name) }
+    end
   end
 end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -40,8 +40,8 @@ module NicePartials
     #
     #  # …which we can then yield into with some predefined options later.
     #  <%= partial.title.yield tag.with_options(class: "text-bold") %>
-    def section(name, content = nil, &block)
-      section_from(name).then { _1.write(content, &block) ? nil : _1 }
+    def section(name, content = nil, **options, &block)
+      section_from(name).then { _1.write(content, **options, &block) ? nil : _1 }
     end
     alias content_for section
 
@@ -70,7 +70,7 @@ module NicePartials
 
     def define_accessor(name)
       name = name.to_s.chomp("?").to_sym
-      self.class.define_method(name) { |content = nil, &block| section(name, content, &block) }
+      self.class.define_method(name) { |content = nil, **options, &block| section(name, content, **options, &block) }
       self.class.define_method("#{name}?") { section?(name) }
     end
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -43,7 +43,7 @@ module NicePartials
     #  # …which is then invoked with some predefined options later.
     #  <%= partial.content_for :title, tag.with_options(class: "text-bold") %>
     def section(name, content = nil, &block)
-      set_named_section(name).process(content, block)
+      section_from(name).process(content, block)
     end
     alias content_for section
 
@@ -58,7 +58,7 @@ module NicePartials
 
     private
 
-    def set_named_section(name)
+    def section_from(name)
       @sections ||= {} and @sections[name] ||= Section.new(@view_context)
     end
 
@@ -72,7 +72,7 @@ module NicePartials
 
     def define_accessor(name)
       name = name.to_s.chomp("?").to_sym
-      self.class.define_method(name) { set_named_section(name) }
+      self.class.define_method(name) { section_from(name) }
       self.class.define_method("#{name}?") { section?(name) }
     end
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -32,6 +32,27 @@ module NicePartials
       class_eval &block
     end
 
+    # Allows an inner partial to copy content from an outer partial.
+    #
+    # Additionally a hash of keys to rename in the new partial context can be passed.
+    #
+    #   First, an outer partial gets some content set:
+    #   <% partial.content_for :title, "Hello there" %>
+    #   <% partial.content_for :byline, "Somebody" %>
+    #
+    #   Second, a new partial is rendered, but we want to extract the title, byline content but rename the byline key too:
+    #   <%= render "shared/title" do |cp| %>
+    #     <% cp.content_from partial, :title, byline: :name %>
+    #   <% end %>
+    #
+    #   # Third, the contents with any renames are accessible in shared/_title.html.erb:
+    #   <%= partial.content_for :title %> # => "Hello there"
+    #   <%= partial.content_for :name %> # => "Somebody"
+    def content_from(partial, *names, **renames)
+      names.chain(renames).each { |key, new_key = key| content_for new_key, partial.content_for(key) }
+      nil
+    end
+
     # Similar to Rails' built-in `content_for` except it defers any block execution
     # and lets you pass arguments into it, like so:
     #

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -37,8 +37,8 @@ module NicePartials
     # Additionally a hash of keys to rename in the new partial context can be passed.
     #
     #   First, an outer partial gets some content set:
-    #   <% partial.content_for :title, "Hello there" %>
-    #   <% partial.content_for :byline, "Somebody" %>
+    #   <% partial.title "Hello there" %>
+    #   <% partial.byline "Somebody" %>
     #
     #   Second, a new partial is rendered, but we want to extract the title, byline content but rename the byline key too:
     #   <%= render "shared/title" do |cp| %>
@@ -46,10 +46,10 @@ module NicePartials
     #   <% end %>
     #
     #   # Third, the contents with any renames are accessible in shared/_title.html.erb:
-    #   <%= partial.content_for :title %> # => "Hello there"
-    #   <%= partial.content_for :name %> # => "Somebody"
+    #   <%= partial.title %> # => "Hello there"
+    #   <%= partial.name %> # => "Somebody"
     def content_from(partial, *names, **renames)
-      names.chain(renames).each { |key, new_key = key| content_for new_key, partial.content_for(key) }
+      names.chain(renames).each { |key, new_key = key| public_send new_key, partial.public_send(key).to_s }
       nil
     end
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -1,0 +1,25 @@
+class NicePartials::Partial::Content
+  def initialize(view_context)
+    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
+  end
+  delegate :to_s, to: :@content
+
+  def content?
+    @content.present?
+  end
+
+  def content_for(content = nil, &block)
+    self unless concat(content || capture(block))
+  end
+
+  private
+
+  def capture(block)
+    @view_context.capture(&block) if block
+  end
+
+  def concat(string)
+    @content << string.presence&.to_s
+    string
+  end
+end

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,8 +4,8 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def write(*arguments, &block)
-    arguments.append(block).compact.filter_map { _1.respond_to?(:call) ? capture(_1) : concat(_1) }.any?
+  def write(content, &block)
+    concat content or capture block
   end
 
   private

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -15,7 +15,6 @@ class NicePartials::Partial::Content
   end
 
   def concat(string)
-    @content << string.presence&.to_s
-    string
+    @content << string.to_s if string.present?
   end
 end

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -5,13 +5,17 @@ class NicePartials::Partial::Content
   delegate :to_s, :present?, to: :@content
 
   def write(content = nil, &block)
-    concat content or capture block
+    append content or capture block
   end
 
   private
 
   def capture(block)
-    concat @view_context.capture(&block) if block
+    append @view_context.capture(&block) if block
+  end
+
+  def append(content)
+    concat content
   end
 
   def concat(string)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -8,9 +8,14 @@ class NicePartials::Partial::Content
     @options ||= {}
   end
 
-  def write(content = nil, **new_options, &block)
+  def write?(content = nil, **new_options, &block)
     process_options new_options
     append content or capture block
+  end
+
+  def write(...)
+    write?(...)
+    self
   end
 
   private

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,9 +4,13 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def options
-    @options ||= {}
-  end
+  # Contains options passed to a partial:
+  #
+  #   <% partial.title class: "post-title" %> # partial.title.options # => { class: "post-title" }
+  #
+  #   # Automatically runs `tag.attributes` when `to_s` is called, e.g.:
+  #   <h1 <% partial.title.options %>> # => <h1 class="post-title">
+  attr_reader :options
 
   def write?(content = nil, **new_options, &block)
     process_options new_options
@@ -21,7 +25,7 @@ class NicePartials::Partial::Content
   private
 
   def process_options(new_options)
-    @options ||= NicePartials.options_class.new and @options.merge!(new_options) unless new_options.empty?
+    @options ||= NicePartials.new_options.(@view_context) and @options.merge!(new_options) unless new_options.empty?
   end
 
   def append(content)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -1,10 +1,13 @@
 class NicePartials::Partial::Content
   def initialize(view_context)
-    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
+    @view_context, @options, @content = view_context, {}, ActiveSupport::SafeBuffer.new
   end
   delegate :to_s, :present?, to: :@content
 
-  def write(content = nil, &block)
+  attr_reader :options
+
+  def write(content = nil, **options, &block)
+    @options.merge! options unless options.empty?
     append content or capture block
   end
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -10,12 +10,17 @@ class NicePartials::Partial::Content
 
   private
 
-  def capture(block)
-    append @view_context.capture(&block) if block
+  def append(content)
+    case
+    when content.respond_to?(:render_in) then concat  content.render_in(@view_context)
+    when content.respond_to?(:call)      then capture content
+    else
+      concat content
+    end
   end
 
-  def append(content)
-    concat content
+  def capture(block)
+    append @view_context.capture(&block) if block
   end
 
   def concat(string)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -21,7 +21,7 @@ class NicePartials::Partial::Content
   private
 
   def process_options(new_options)
-    @options = NicePartials.options_processor.call(options, new_options) unless new_options.empty?
+    @options ||= NicePartials.options_class.new and @options.merge!(new_options) unless new_options.empty?
   end
 
   def append(content)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -2,11 +2,7 @@ class NicePartials::Partial::Content
   def initialize(view_context)
     @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
   end
-  delegate :to_s, to: :@content
-
-  def content?
-    @content.present?
-  end
+  delegate :to_s, :present?, to: :@content
 
   def content_for(content = nil, &block)
     self unless concat(content || capture(block))

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -1,10 +1,10 @@
 class NicePartials::Partial::Content
+  attr_reader :options
+
   def initialize(view_context)
     @view_context, @options, @content = view_context, {}, ActiveSupport::SafeBuffer.new
   end
   delegate :to_s, :present?, to: :@content
-
-  attr_reader :options
 
   def write(content = nil, **options, &block)
     @options.merge! options unless options.empty?

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,14 +4,18 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def process(content, block)
-    self unless concat(content || capture(block))
+  def process(*arguments)
+    self unless write(*arguments)
+  end
+
+  def write(*arguments, &block)
+    arguments.append(block).filter_map { _1.respond_to?(:call) ? capture(_1) : concat(_1) }.any?
   end
 
   private
 
   def capture(block)
-    @view_context.capture(&block) if block
+    concat @view_context.capture(&block) if block
   end
 
   def concat(string)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,7 +4,7 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def content_for(content = nil, &block)
+  def process(content, block)
     self unless concat(content || capture(block))
   end
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,7 +4,7 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def write(content, &block)
+  def write(content = nil, &block)
     concat content or capture block
   end
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -1,17 +1,23 @@
 class NicePartials::Partial::Content
-  attr_reader :options
-
   def initialize(view_context)
-    @view_context, @options, @content = view_context, {}, ActiveSupport::SafeBuffer.new
+    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
   end
   delegate :to_s, :present?, to: :@content
 
-  def write(content = nil, **options, &block)
-    @options.merge! options unless options.empty?
+  def options
+    @options ||= {}
+  end
+
+  def write(content = nil, **new_options, &block)
+    process_options new_options
     append content or capture block
   end
 
   private
+
+  def process_options(new_options)
+    @options = NicePartials.options_processor.call(options, new_options) unless new_options.empty?
+  end
 
   def append(content)
     case

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -4,10 +4,6 @@ class NicePartials::Partial::Content
   end
   delegate :to_s, :present?, to: :@content
 
-  def process(*arguments)
-    self unless write(*arguments)
-  end
-
   def write(*arguments, &block)
     arguments.append(block).compact.filter_map { _1.respond_to?(:call) ? capture(_1) : concat(_1) }.any?
   end

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -9,7 +9,7 @@ class NicePartials::Partial::Content
   end
 
   def write(*arguments, &block)
-    arguments.append(block).filter_map { _1.respond_to?(:call) ? capture(_1) : concat(_1) }.any?
+    arguments.append(block).compact.filter_map { _1.respond_to?(:call) ? capture(_1) : concat(_1) }.any?
   end
 
   private

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -11,9 +11,12 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
   # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
   # and `partial.body.link_to @document.name, @document`
   def method_missing(meth, *arguments, **keywords, &block)
-    if @view_context.respond_to?(meth)
+    case
+    when @view_context.respond_to?(meth)
       concat @view_context.public_send(meth, *arguments, **keywords, &block)
       nil
+    when @view_context.tag.respond_to?(meth)
+      @view_context.tag.public_send(meth, @content, **@options)
     else
       super
     end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -10,8 +10,21 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
 
   undef_method :p # Remove Kernel.p here to pipe through method_missing and hit tag proxy.
 
-  # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
-  # and `partial.body.link_to @document.name, @document`
+  # Implements our proxying to the `@view_context` or `@view_context.tag`.
+  #
+  # `@view_context` proxying forwards the message and automatically appends any content, so you can do things like:
+  #
+  #   <% partial.body.render "form", tangible_thing: @tangible_thing %>
+  #   <% partial.body.link_to @document.name, @document %>
+  #   <% partial.body.t ".body" %>
+  #
+  # `@view_context.tag` proxy lets you build bespoke elements based on content and options provided:
+  #
+  #    <% partial.title "Some title content", class: "xl" %> # Write the content and options to the `title`
+  #    <% partial.title.h2 ", appended" %> # => <h2 class="xl">Some title content, appended</h2>
+  #
+  # Note that NicePartials don't support deep merging attributes out of the box.
+  # For that, bundle https://github.com/seanpdoyle/attributes_and_token_lists
   def method_missing(meth, *arguments, **keywords, &block)
     if meth != :p && @view_context.respond_to?(meth)
       concat @view_context.public_send(meth, *arguments, **keywords, &block)

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -16,7 +16,7 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
       concat @view_context.public_send(meth, *arguments, **keywords, &block)
       nil
     when @view_context.tag.respond_to?(meth)
-      @view_context.tag.public_send(meth, @content, **@options)
+      @view_context.tag.public_send(meth, @content, **options)
     else
       super
     end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,5 +1,22 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
-  def content_for(content = nil)
-    self unless concat(content)
+  def yield(*arguments)
+    chunks.each { concat @view_context.capture(*arguments, &_1) }
+    self
   end
+
+  def present?
+    chunks.present? || super
+  end
+
+  private
+
+  def capture(block)
+    if block&.arity&.nonzero?
+      chunks << block and nil
+    else
+      super
+    end
+  end
+
+  def chunks() = @chunks ||= []
 end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,7 +1,6 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
-  def store(*new_chunks, &block)
-    chunks.concat new_chunks
-    chunks << block if block_given?
+  def store(chunk = nil, &block)
+    chunks.concat [ chunk, block ].compact
     nil
   end
 

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -8,17 +8,16 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
     chunks.present? || super
   end
 
+  undef_method :p # Remove Kernel.p here to pipe through method_missing and hit tag proxy.
+
   # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
   # and `partial.body.link_to @document.name, @document`
   def method_missing(meth, *arguments, **keywords, &block)
-    case
-    when @view_context.respond_to?(meth)
+    if meth != :p && @view_context.respond_to?(meth)
       concat @view_context.public_send(meth, *arguments, **keywords, &block)
       nil
-    when @view_context.tag.respond_to?(meth)
-      @view_context.tag.public_send(meth, @content, **options)
     else
-      super
+      @view_context.tag.public_send(meth, @content + arguments.first.to_s, **options.merge(keywords), &block)
     end
   end
   def respond_to_missing?(...) = @view_context.respond_to?(...)

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -9,6 +9,12 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
     self
   end
 
+  # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
+  def render(...)
+    concat @view_context.render(...)
+    self
+  end
+
   def present?
     chunks.present? || super
   end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,9 +1,4 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
-  def store(chunk = nil, &block)
-    chunks.concat [ chunk, block ].compact
-    nil
-  end
-
   def yield(*arguments)
     chunks.each { concat @view_context.capture(*arguments, &_1) }
     self

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,9 +1,4 @@
-class NicePartials::Partial::Section
-  def initialize(view_context)
-    @view_context = view_context
-    @content = @pending_content = nil
-  end
-
+class NicePartials::Partial::Section < NicePartials::Partial::Content
   def content_for(*arguments, &block)
     if write_content_for(arguments.first, &block)
       nil
@@ -30,11 +25,6 @@ class NicePartials::Partial::Section
   def capture_content_for(*arguments)
     concat @view_context.capture(*arguments, &@pending_content)
     @pending_content = nil
-  end
-
-  def concat(string)
-    @content ||= ActiveSupport::SafeBuffer.new
-    @content << string.to_s if string.present?
   end
 
   def pending?

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -28,7 +28,6 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
   def method_missing(meth, *arguments, **keywords, &block)
     if meth != :p && @view_context.respond_to?(meth)
       append @view_context.public_send(meth, *arguments, **keywords, &block)
-      nil
     else
       @view_context.tag.public_send(meth, @content + arguments.first.to_s, **options.merge(keywords), &block)
     end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,33 +1,5 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
-  def content_for(*arguments, &block)
-    if write_content_for(arguments.first, &block)
-      nil
-    else
-      capture_content_for(*arguments) if pending?
-      @content
-    end
-  end
-
-  def content?
-    pending? || @content
-  end
-
-  private
-
-  def write_content_for(content = nil, &block)
-    if content && !pending?
-      concat content
-    else
-      @pending_content = block if block
-    end
-  end
-
-  def capture_content_for(*arguments)
-    concat @view_context.capture(*arguments, &@pending_content)
-    @pending_content = nil
-  end
-
-  def pending?
-    @pending_content
+  def content_for(content = nil)
+    self unless concat(content)
   end
 end

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,6 +1,6 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
   def yield(*arguments)
-    chunks.each { concat @view_context.capture(*arguments, &_1) }
+    chunks.each { append @view_context.capture(*arguments, &_1) }
     self
   end
 

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -1,4 +1,10 @@
 class NicePartials::Partial::Section < NicePartials::Partial::Content
+  def store(*new_chunks, &block)
+    chunks.concat new_chunks
+    chunks << block if block_given?
+    nil
+  end
+
   def yield(*arguments)
     chunks.each { concat @view_context.capture(*arguments, &_1) }
     self

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -27,7 +27,7 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
   # For that, bundle https://github.com/seanpdoyle/attributes_and_token_lists
   def method_missing(meth, *arguments, **keywords, &block)
     if meth != :p && @view_context.respond_to?(meth)
-      concat @view_context.public_send(meth, *arguments, **keywords, &block)
+      append @view_context.public_send(meth, *arguments, **keywords, &block)
       nil
     else
       @view_context.tag.public_send(meth, @content + arguments.first.to_s, **options.merge(keywords), &block)

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -4,15 +4,21 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
     self
   end
 
-  # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
-  def render(...)
-    concat @view_context.render(...)
-    self
-  end
-
   def present?
     chunks.present? || super
   end
+
+  # Allows for doing `partial.body.render "form", tangible_thing: @tangible_thing`
+  # and `partial.body.link_to @document.name, @document`
+  def method_missing(meth, *arguments, **keywords, &block)
+    if @view_context.respond_to?(meth)
+      concat @view_context.public_send(meth, *arguments, **keywords, &block)
+      nil
+    else
+      super
+    end
+  end
+  def respond_to_missing?(...) = @view_context.respond_to?(...)
 
   private
 

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -12,7 +12,7 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
 
   def capture(block)
     if block&.arity&.nonzero?
-      chunks << block and nil
+      chunks << block
     else
       super
     end

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -2,9 +2,10 @@
   <%= partial.yield :image %>
   <div class="card-body">
     <h5 class="card-title"><%= title %></h5>
-    <% if partial.content_for? :body %>
+    <% if partial.section? :body %>
       <p class="card-text">
-        <%= partial.content_for :body, tag.with_options(class: "text-bold") %>
+        <%# TODO: remove send pending https://github.com/bullet-train-co/nice_partials/pull/54 %>
+        <%= partial.section(:body).send :yield, tag.with_options(class: "text-bold") %>
       </p>
     <% end %>
   </div>

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -2,10 +2,10 @@
   <%= partial.yield :image %>
   <div class="card-body">
     <h5 class="card-title"><%= title %></h5>
-    <% if partial.section? :body %>
+    <% if partial.body? %>
       <p class="card-text">
         <%# TODO: remove send pending https://github.com/bullet-train-co/nice_partials/pull/54 %>
-        <%= partial.section(:body).send :yield, tag.with_options(class: "text-bold") %>
+        <%= partial.body.send :yield, tag.with_options(class: "text-bold") %>
       </p>
     <% end %>
   </div>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,5 +1,5 @@
 <%= render "card", title: "Some Title" do |partial| %>
-  <% partial.body.store -> { _1.p "Lorem Ipsum" } %>
+  <% partial.body.write { _1.p "Lorem Ipsum" } %>
 
   <% partial.content_for :image do %>
     <img src="https://example.com/image.jpg" />

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,7 +1,7 @@
 <%= render "card", title: "Some Title" do |p| %>
-  <% p.content_for :body do |tag| %>
-    <%= tag.p "Lorem Ipsum" %>
-  <% end %>
+  <%# <% p.content_for :body do |tag| %> %>
+    <%# <%= tag.p "Lorem Ipsum" %> %>
+  <%# <% end %> %>
 
   <% p.content_for :image do %>
     <img src="https://example.com/image.jpg" />

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,5 +1,5 @@
 <%= render "card", title: "Some Title" do |partial| %>
-  <% partial.body.write { _1.p "Lorem Ipsum" } %>
+  <% partial.body { _1.p "Lorem Ipsum" } %>
 
   <% partial.content_for :image do %>
     <img src="https://example.com/image.jpg" />

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,5 +1,5 @@
 <%= render "card", title: "Some Title" do |partial| %>
-  <% partial.body.write -> { _1.p "Lorem Ipsum" } %>
+  <% partial.body.store -> { _1.p "Lorem Ipsum" } %>
 
   <% partial.content_for :image do %>
     <img src="https://example.com/image.jpg" />

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,7 +1,4 @@
 <%= render "card", title: "Some Title" do |partial| %>
   <% partial.body { _1.p "Lorem Ipsum" } %>
-
-  <% partial.content_for :image do %>
-    <img src="https://example.com/image.jpg" />
-  <% end %>
+  <% partial.image.image_tag "https://example.com/image.jpg" %>
 <% end %>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,9 +1,9 @@
-<%= render "card", title: "Some Title" do |p| %>
-  <%# <% p.content_for :body do |tag| %> %>
-    <%# <%= tag.p "Lorem Ipsum" %> %>
-  <%# <% end %> %>
+<%= render "card", title: "Some Title" do |partial| %>
+  <% partial.section :body do |tag| %>
+    <%= tag.p "Lorem Ipsum" %>
+  <% end %>
 
-  <% p.content_for :image do %>
+  <% partial.content_for :image do %>
     <img src="https://example.com/image.jpg" />
   <% end %>
 <% end %>

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,7 +1,5 @@
 <%= render "card", title: "Some Title" do |partial| %>
-  <% partial.body.write do |tag| %>
-    <%= tag.p "Lorem Ipsum" %>
-  <% end %>
+  <% partial.body.write -> { _1.p "Lorem Ipsum" } %>
 
   <% partial.content_for :image do %>
     <img src="https://example.com/image.jpg" />

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,5 +1,5 @@
 <%= render "card", title: "Some Title" do |partial| %>
-  <% partial.section :body do |tag| %>
+  <% partial.body.write do |tag| %>
     <%= tag.p "Lorem Ipsum" %>
   <% end %>
 

--- a/test/fixtures/translations/_nice_partials_translated.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated.html.erb
@@ -1,3 +1,3 @@
 <%= render("basic") do |partial| %>
-  <%= partial.content_for :message, t(".message") %>
+  <%= partial.message.t ".message" %>
 <% end %>

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -30,6 +30,7 @@ class NicePartials::PartialTest < NicePartials::Test
     partial.body.link_to "Document", "document_url"
 
     partial.body Component.new(:plain)
+    partial.body.render Component.new(:render)
     partial.body { render Component.new(:from_block) }
 
     partial.body LinkComponent.new("nice_partials")
@@ -43,6 +44,7 @@ class NicePartials::PartialTest < NicePartials::Test
       content from another partial
       <a href="document_url">Document</a>
       component render_in plain
+      component render_in render
       component render_in from_block
       <a href="example.com/nice_partials">view_component.link_to</a>
       <a href="example.com/nice_partials">view_component.link_to</a>

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -52,14 +52,17 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     partial = new_partial
     partial.title "content", class: "post-title"
 
-    assert_equal({ class: "post-title" }, partial.title.options)
-    assert_equal %(class="post-title"),   partial.title.options.to_s
+    assert_equal "post-title",          partial.title.options[:class]
+    assert_equal %(class="post-title"), partial.title.options.to_s
 
-    assert_equal %(<p class="post-title">content</p>),         partial.title.p
-    assert_equal %(<h2 class="post-title">content</h2>),       partial.title.h2
-    assert_equal %(<h2 class="">content</h2>),                 partial.title.h2(class: { "text-m4": false }), "tag proxy didn't support token_list attributes"
-    assert_equal %(<h2 class="text-m4">contentaddendum</h2>),  partial.title.h2("addendum", class: "text-m4")
-    assert_equal %(<h2 class="some-class">contentblabla</h2>), partial.title.h2("blabla", class: "some-class")
+    assert_equal %(<p class="post-title">content</p>),   partial.title.p
+    assert_equal %(<h2 class="post-title">content</h2>), partial.title.h2
+
+    unless defined?(AttributesAndTokenLists)
+      assert_equal %(<h2 class="">content</h2>),                 partial.title.h2(class: { "text-m4": false })
+      assert_equal %(<h2 class="text-m4">contentaddendum</h2>),  partial.title.h2("addendum", class: "text-m4")
+      assert_equal %(<h2 class="some-class">contentblabla</h2>), partial.title.h2("blabla", class: "some-class")
+    end
   end
 
   private

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -50,10 +50,14 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
 
   test "tag proxy with options" do
     partial = new_partial
-    partial.title class: "post-title"
+    partial.title "content", class: "post-title"
 
     assert_equal({ class: "post-title" }, partial.title.options)
-    assert_equal %(<h2 class="post-title"></h2>), partial.title.h2
+    assert_equal %(<p class="post-title">content</p>),         partial.title.p
+    assert_equal %(<h2 class="post-title">content</h2>),       partial.title.h2
+    assert_equal %(<h2 class="">content</h2>),                 partial.title.h2(class: { "text-m4": false }), "tag proxy didn't support token_list attributes"
+    assert_equal %(<h2 class="text-m4">contentaddendum</h2>),  partial.title.h2("addendum", class: "text-m4")
+    assert_equal %(<h2 class="some-class">contentblabla</h2>), partial.title.h2("blabla", class: "some-class")
   end
 
   private

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -24,6 +24,8 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     partial = new_partial
     partial.body "some content"
 
+    partial.body new_partial.body.tap { _1.write("content from another partial") }
+
     partial.body Component.new(:plain)
     partial.body { Component.new(:from_block) }
 
@@ -32,6 +34,7 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
 
     assert_equal <<~OUTPUT.gsub("\n", ""), partial.body.to_s
       some content
+      content from another partial
       component render_in plain
       component render_in from_block
       yielded content, appended to

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -53,6 +53,8 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     partial.title "content", class: "post-title"
 
     assert_equal({ class: "post-title" }, partial.title.options)
+    assert_equal %(class="post-title"),   partial.title.options.to_s
+
     assert_equal %(<p class="post-title">content</p>),         partial.title.p
     assert_equal %(<h2 class="post-title">content</h2>),       partial.title.h2
     assert_equal %(<h2 class="">content</h2>),                 partial.title.h2(class: { "text-m4": false }), "tag proxy didn't support token_list attributes"

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -5,6 +5,11 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     def initialize
     end
 
+    LookupContext = Struct.new(:variants)
+    def lookup_context
+      LookupContext.new([])
+    end
+
     def link_to(name, url)
       %(<a href="#{url}">#{name}</a>).html_safe
     end
@@ -24,6 +29,16 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     end
   end
 
+  class LinkComponent < ViewComponent::Base
+    def initialize(name)
+      @name = name
+    end
+
+    def call
+      link_to "view_component.link_to", "example.com/#{@name}"
+    end
+  end
+
   test "appending content types consecutively" do
     partial = new_partial
     partial.body "some content"
@@ -35,6 +50,9 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     partial.body Component.new(:plain)
     partial.body { Component.new(:from_block) }
 
+    partial.body LinkComponent.new("nice_partials")
+    partial.body { LinkComponent.new("nice_partials") }
+
     partial.body { _1 << ", appended to" }
     partial.body.yield "yielded content"
 
@@ -44,6 +62,8 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
       <a href="document_url">Document</a>
       component render_in plain
       component render_in from_block
+      <a href="example.com/nice_partials">view_component.link_to</a>
+      <a href="example.com/nice_partials">view_component.link_to</a>
       yielded content, appended to
     OUTPUT
   end

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -69,6 +69,15 @@ class NicePartials::PartialTest < NicePartials::Test
     end
   end
 
+  test "content_for returns content itself and not section object" do
+    partial = new_partial
+    partial.body "some content"
+    partial.content_for :body, ", yet more"
+
+    assert_equal "some content, yet more", partial.content_for(:body)
+    assert_equal "some content, yet more", partial.body.to_s
+  end
+
   private
 
   def new_partial

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -30,10 +30,10 @@ class NicePartials::PartialTest < NicePartials::Test
     partial.body.link_to "Document", "document_url"
 
     partial.body Component.new(:plain)
-    partial.body { Component.new(:from_block) }
+    partial.body { render Component.new(:from_block) }
 
     partial.body LinkComponent.new("nice_partials")
-    partial.body { LinkComponent.new("nice_partials") }
+    partial.body { render LinkComponent.new("nice_partials") }
 
     partial.body { _1 << ", appended to" }
     partial.body.yield "yielded content"

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -5,6 +5,10 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     def initialize
     end
 
+    def link_to(name, url)
+      %(<a href="#{url}">#{name}</a>).html_safe
+    end
+
     def capture(*arguments)
       yield(*arguments)
     end
@@ -26,6 +30,8 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
 
     partial.body new_partial.body.tap { _1.write("content from another partial") }
 
+    partial.body.link_to "Document", "document_url"
+
     partial.body Component.new(:plain)
     partial.body { Component.new(:from_block) }
 
@@ -35,6 +41,7 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     assert_equal <<~OUTPUT.gsub("\n", ""), partial.body.to_s
       some content
       content from another partial
+      <a href="document_url">Document</a>
       component render_in plain
       component render_in from_block
       yielded content, appended to

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -48,6 +48,14 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  test "tag proxy with options" do
+    partial = new_partial
+    partial.title class: "post-title"
+
+    assert_equal({ class: "post-title" }, partial.title.options)
+    assert_equal %(<h2 class="post-title"></h2>), partial.title.h2
+  end
+
   private
 
   def new_partial

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -78,6 +78,47 @@ class NicePartials::PartialTest < NicePartials::Test
     assert_equal "some content, yet more", partial.body.to_s
   end
 
+  test "content_from with immediate contents" do
+    outer_partial, inner_partial = new_partial, new_partial
+    outer_partial.title "Hello there"
+
+    inner_partial.content_from outer_partial, :title
+    inner_partial.title ", and furthermore"
+
+    assert_equal "Hello there, and furthermore", inner_partial.title.to_s
+    assert_equal "Hello there", outer_partial.title.to_s
+  end
+
+  test "content_from with deferred contents" do
+    outer_partial, inner_partial = new_partial, new_partial
+    outer_partial.message { "Deferred" }
+
+    inner_partial.content_from outer_partial, :message
+    inner_partial.message { ", and furthermore" }
+
+    assert_equal "Deferred, and furthermore", inner_partial.message.to_s
+    assert_equal "Deferred", outer_partial.message.to_s
+  end
+
+  test "content_from with missing contents" do
+    outer_partial, inner_partial = new_partial, new_partial
+
+    inner_partial.content_from outer_partial, :title
+
+    assert_empty inner_partial.title.to_s
+    assert_empty outer_partial.title.to_s
+  end
+
+  test "content_from with renaming" do
+    outer_partial, inner_partial = new_partial, new_partial
+    outer_partial.title "Hello there"
+
+    inner_partial.content_from outer_partial, title: :byline
+
+    assert_equal "Hello there", inner_partial.byline.to_s
+    assert_equal "Hello there", outer_partial.title.to_s
+  end
+
   private
 
   def new_partial

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class NicePartials::PartialTest < ActiveSupport::TestCase
+  class StubbedViewContext < ActionView::Base
+    def initialize
+    end
+
+    def capture(*arguments)
+      yield(*arguments)
+    end
+  end
+
+  class Component
+    def initialize(key)
+      @key = key
+    end
+
+    def render_in(view_context)
+      "component render_in #{@key}"
+    end
+  end
+
+  test "appending content types consecutively" do
+    partial = new_partial
+    partial.body "some content"
+
+    partial.body Component.new(:plain)
+    partial.body { Component.new(:from_block) }
+
+    partial.body { _1 << ", appended to" }
+    partial.body.yield "yielded content"
+
+    assert_equal <<~OUTPUT.gsub("\n", ""), partial.body.to_s
+      some content
+      component render_in plain
+      component render_in from_block
+      yielded content, appended to
+    OUTPUT
+  end
+
+  private
+
+  def new_partial
+    NicePartials::Partial.new StubbedViewContext.new
+  end
+end

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -1,24 +1,6 @@
 require "test_helper"
 
-class NicePartials::PartialTest < ActiveSupport::TestCase
-  class StubbedViewContext < ActionView::Base
-    def initialize
-    end
-
-    LookupContext = Struct.new(:variants)
-    def lookup_context
-      LookupContext.new([])
-    end
-
-    def link_to(name, url)
-      %(<a href="#{url}">#{name}</a>).html_safe
-    end
-
-    def capture(*arguments)
-      yield(*arguments)
-    end
-  end
-
+class NicePartials::PartialTest < NicePartials::Test
   class Component
     def initialize(key)
       @key = key
@@ -88,6 +70,6 @@ class NicePartials::PartialTest < ActiveSupport::TestCase
   private
 
   def new_partial
-    NicePartials::Partial.new StubbedViewContext.new
+    NicePartials::Partial.new view
   end
 end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -11,7 +11,7 @@ class RendererTest < NicePartials::Test
     render(template: "card_test")
 
     assert_rendered "Some Title"
-    # assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
+    assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
     assert_rendered "https://example.com/image.jpg"
   end
 

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -11,7 +11,7 @@ class RendererTest < NicePartials::Test
     render(template: "card_test")
 
     assert_rendered "Some Title"
-    assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
+    # assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
     assert_rendered "https://example.com/image.jpg"
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,14 @@
-require "active_support"
-require "active_support/testing/autorun"
-require "action_controller"
-require "action_view"
-require "action_view/test_case"
+ENV["RAILS_ENV"] = "test"
+require "rails"
+require "rails/test_help"
 
+class TestApp < Rails::Application
+  config.root = __dir__
+  config.hosts << "example.org"
+  secrets.secret_key_base = "secret_key_base"
+end
+
+require "view_component"
 require "nice_partials"
 
 class NicePartials::Test < ActionView::TestCase


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/nice_partials/issues/11

Sometimes there's a partial that'd like the named contents of another.

`content_from` lets a partial sift the content, and pass a hash to rename sections,
from the outer partial:

```erb
<% partial.content_for :title, "Hello there" %>
<% partial.content_for :byline, "Somebody" %>

<%= render "shared/title" do |cp| %>
  <% cp.content_from partial, :title, byline: :name %>
<% end %>
```

Sprung out of the discussion in https://github.com/bullet-train-co/nice_partials/issues/38, though I didn't feel the need to add `parent` tracking and flipped the call order, so the inner partial extracts from the outer and that feels clearer what context we're currently in.