### PR TITLE
Introduce Capybara to the test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem "minitest"
 gem "rake"
 gem "irb"
+gem "capybara"

--- a/test/renderer/translation_test.rb
+++ b/test/renderer/translation_test.rb
@@ -15,12 +15,12 @@ class Renderer::TranslationTest < NicePartials::Test
   test "clean translation render" do
     render "translations/translated"
 
-    assert_rendered "message"
+    assert_text "message"
   end
 
   test "translations insert prefix from originating partial" do
     render "translations/nice_partials_translated"
 
-    assert_rendered "nice_partials"
+    assert_text "nice_partials"
   end
 end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -4,24 +4,24 @@ class RendererTest < NicePartials::Test
   test "render basic nice partial" do
     render("basic") { |p| p.content_for :message, "hello from nice partials" }
 
-    assert_rendered "hello from nice partials"
+    assert_text "hello from nice partials"
   end
 
   test "render nice partial in card template" do
     render(template: "card_test")
 
-    assert_rendered "Some Title"
-    assert_rendered '<p class="text-bold">Lorem Ipsum</p>'
-    assert_rendered "https://example.com/image.jpg"
+    assert_text "Some Title"
+    assert_css "p", class: "text-bold", text: "Lorem Ipsum"
+    assert_css("img") { _1["src"] == "https://example.com/image.jpg" }
   end
 
   test "accessing partial in outer context won't leak state to inner render" do
     render "partial_accessed_in_outer_context"
 
-    assert_rendered "hello"
-    assert_rendered "goodbye"
-    assert_rendered "<span></span>"
-    assert_not_includes rendered, "hellogoodbye"
+    assert_text "hello"
+    assert_text "goodbye"
+    assert_css "span", text: ""
+    assert_no_text "hellogoodbye"
   end
 
   test "explicit yield without any arguments auto-captures passed block" do
@@ -50,7 +50,7 @@ class RendererTest < NicePartials::Test
       tag.span "Output in outer partial through yield"
     end
 
-    assert_rendered "<span>Output in outer partial through yield</span>"
+    assert_css "span", text: "Output in outer partial through yield"
   end
 
   test "output_buffer captures content not written via yield/content_for" do
@@ -61,7 +61,7 @@ class RendererTest < NicePartials::Test
       "Some extra content"
     end
 
-    assert_rendered "hello from nice partials"
+    assert_text "hello from nice partials"
     assert_equal "Some extra content", nice_partial.yield
   end
 
@@ -70,7 +70,7 @@ class RendererTest < NicePartials::Test
       render("clobberer") { |p| p.content_for :message, "hello from nice partials" }
     end
 
-    assert_rendered "hello from nice partials"
+    assert_text "hello from nice partials"
   end
 
   test "deprecates top-level access through p method" do

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -12,7 +12,7 @@ class RendererTest < NicePartials::Test
 
     assert_text "Some Title"
     assert_css "p", class: "text-bold", text: "Lorem Ipsum"
-    assert_css("img") { _1["src"] == "https://example.com/image.jpg" }
+    assert_css("img") { assert_equal "https://example.com/image.jpg", _1["src"] }
   end
 
   test "accessing partial in outer context won't leak state to inner render" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,15 +3,18 @@ require "active_support/testing/autorun"
 require "action_controller"
 require "action_view"
 require "action_view/test_case"
+require "capybara/minitest"
 
 require "nice_partials"
 
 class NicePartials::Test < ActionView::TestCase
+  include Capybara::Minitest::Assertions
+
   TestController.view_paths << "test/fixtures"
 
   private
 
-  def assert_rendered(matcher)
-    assert_match matcher, rendered
+  def page
+    @page ||= Capybara.string(rendered)
   end
 end


### PR DESCRIPTION
Add a dependency on Capybara, and includes the
[Capybara::Minitest::Assertions][] module into `NicePartials::Test`.

[Capybara::Minitest::Assertions]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions