### PR TITLE
Add `NicePartials#t` to aid I18n.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
 
   Clarifying what keys get converted to what content sections on the partial rather than the boilerplate heavy and repetitive `partial.… t(".…")`.
 
+### 0.1.9
+
 * Remove need to insert `<% yield p = np %>` in partials.
 
   Nice Partials now automatically captures blocks passed to `render`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,24 @@
   <% partial.title.h2 "more" %> # => <h2 class="post-title">contentmore</h2>
   ```
 
+* Add `NicePartials#t` to aid I18n.
+
+  When using NicePartials with I18n you end up with lots of calls that look like:
+
+  ```erb
+  <% partial.title       t(".title") %>
+  <% partial.description t(".header") %>
+  <% partial.byline      t("custom.key") %>
+  ```
+
+  With NicePartials' `t` method, you can write the above as:
+
+  ```erb
+  <% partial.t :title, description: :header, byline: "custom.key" %>
+  ```
+
+  Clarifying what keys get converted to what content sections on the partial rather than the boilerplate heavy and repetitive `partial.… t(".…")`.
+
 * Remove need to insert `<% yield p = np %>` in partials.
 
   Nice Partials now automatically captures blocks passed to `render`.

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -32,6 +32,23 @@ module NicePartials
       class_eval &block
     end
 
+    # `translate` is a shorthand to set `content_for` with content that's run through
+    # the view's `translate`/`t` context.
+    #
+    #   partial.t :title                       # => partial.content_for :title, t(".title")
+    #   partial.t title: :section              # => partial.content_for :title, t(".section")
+    #   partial.t title: "some.custom.key"     # => partial.content_for :title, t("some.custom.key")
+    #   partial.t :description, title: :header # Mixing is supported too.
+    #
+    # Note that `partial.t "some.custom.key"` can't derive a `content_for` name, so an explicit
+    # name must be provided e.g. `partial.t title: "some.custom.key"`.
+    def translate(*names, **renames)
+      names.chain(renames).each do |name, key = name|
+        content_for name, @view_context.t(key.is_a?(String) ? key : ".#{key}")
+      end
+    end
+    alias t translate
+
     # Similar to Rails' built-in `content_for` except it defers any block execution
     # and lets you pass arguments into it, like so:
     #

--- a/test/fixtures/translations/_t.html.erb
+++ b/test/fixtures/translations/_t.html.erb
@@ -1,0 +1,1 @@
+<%= partial.t :title, description: :header, byline: "custom.key" %>

--- a/test/renderer/translation_test.rb
+++ b/test/renderer/translation_test.rb
@@ -4,10 +4,12 @@ module Renderer; end
 
 class Renderer::TranslationTest < NicePartials::Test
   setup do
-    I18n.backend.store_translations "en", { translations: {
+    I18n.backend.store_translations "en", translations: {
       translated: { message: "message" },
-      nice_partials_translated: { message: "nice_partials" }
-    } }
+      nice_partials_translated: { message: "nice_partials" },
+      t: { title: "title key content", header: "header key content" },
+    }
+    I18n.backend.store_translations "en", custom: { key: "custom key content" }
   end
 
   teardown { I18n.reload! }
@@ -22,5 +24,14 @@ class Renderer::TranslationTest < NicePartials::Test
     render "translations/nice_partials_translated"
 
     assert_rendered "nice_partials"
+  end
+
+  test "translate method" do
+    partial = nil
+    render("translations/t") { partial = _1 }
+
+    assert_equal "title key content",  partial.content_for(:title)
+    assert_equal "header key content", partial.content_for(:description)
+    assert_equal "custom key content", partial.content_for(:byline)
   end
 end

--- a/test/renderer/translation_test.rb
+++ b/test/renderer/translation_test.rb
@@ -30,8 +30,8 @@ class Renderer::TranslationTest < NicePartials::Test
     partial = nil
     render("translations/t") { partial = _1 }
 
-    assert_equal "title key content",  partial.content_for(:title)
-    assert_equal "header key content", partial.content_for(:description)
-    assert_equal "custom key content", partial.content_for(:byline)
+    assert_equal "title key content",  partial.title.to_s
+    assert_equal "header key content", partial.description.to_s
+    assert_equal "custom key content", partial.byline.to_s
   end
 end


### PR DESCRIPTION
When using NicePartials with I18n you end up with lots of calls that look like:

```erb
<%= partial.content_for :title,       t(".title") %>
<%= partial.content_for :description, t(".header") %>
<%= partial.content_for :byline,      t("custom.key") %>
```

With NicePartials `t` method you can write the above as:

```erb
<%= partial.t :title, description: :header, byline: "custom.key" %>
```

Clarifying what keys get converted to what content sections on the partial rather than the boilerplate heavy and repetitive `content_for(…), t(".…")`.