### PR TITLE
Skip needless CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,13 @@ jobs:
     #   - image: circleci/redis
     executor: ruby/default
     steps:
-      - browser-tools/install-browser-tools
+      # - browser-tools/install-browser-tools
       - checkout
 
       # Install dependencies
       - run: "bundle install"
       - run: "bundle clean --force"
-      - run: "yarn install"
+      # - run: "yarn install"
       # - *wait_for_docker
       - run:
           name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ aliases:
       run: dockerize -wait tcp://localhost:5432 -timeout 1m
 jobs:
   'Local Minitest':
-    docker:
-      - <<: *ruby_node_browsers_docker_image
-      - <<: *postgres_docker_image
-      - image: circleci/redis
+    # docker:
+    #   - <<: *ruby_node_browsers_docker_image
+    #   - <<: *postgres_docker_image
+    #   - image: circleci/redis
     executor: ruby/default
     steps:
       - browser-tools/install-browser-tools
@@ -55,7 +55,7 @@ jobs:
       - run: "bundle install"
       - run: "bundle clean --force"
       - run: "yarn install"
-      - *wait_for_docker
+      # - *wait_for_docker
       - run:
           name: Run unit tests
           command: bin/test


### PR DESCRIPTION
For the local Ruby tests we don't need a lot of the regular Bullet Train test harness. So we can comment those out and save a 30+ seconds of setup and needless CI time. I'm commenting out instead of removing so it's easier to add the steps back should we need them — or just comparing with other Bullet Train libs.