### PR TITLE
Bugfix: Partial Options Nil Pointer Exception

### DIFF
--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -11,6 +11,7 @@ class NicePartials::Partial::Content
 
   def initialize(view_context)
     @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
+    @options = Options.new(@view_context)
   end
   delegate :to_s, :present?, to: :@content
 
@@ -23,7 +24,7 @@ class NicePartials::Partial::Content
   attr_reader :options
 
   def write?(content = nil, **new_options, &block)
-    process_options new_options
+    @options.merge! new_options
     append content or capture block
   end
 
@@ -33,10 +34,6 @@ class NicePartials::Partial::Content
   end
 
   private
-
-  def process_options(new_options)
-    @options ||= Options.new(@view_context) and @options.merge!(new_options) unless new_options.empty?
-  end
 
   def append(content)
     case

--- a/test/fixtures/_columns.html.erb
+++ b/test/fixtures/_columns.html.erb
@@ -1,0 +1,4 @@
+<div class="grid gap-2">
+  <%= partial.left.div id: "left" %>
+  <%= partial.right.div id: "right" %>
+</div>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -15,6 +15,30 @@ class RendererTest < NicePartials::Test
     assert_css("img") { assert_equal "https://example.com/image.jpg", _1["src"] }
   end
 
+  test "render with options from call site" do
+    render "columns" do |partial|
+      partial.left "The Left", class: "left-column"
+      partial.right "The Right", class: "right-column"
+    end
+
+    assert_css "div", class: %w[grid gap-2] do
+      assert_css "div", id: "left", class: "left-column", text: "The Left", count: 1
+      assert_css "div", id: "right", class: "right-column", text: "The Right", count: 1
+    end
+  end
+
+  test "render without options from call site" do
+    render "columns" do |partial|
+      partial.left "The Left"
+      partial.right "The Right"
+    end
+
+    assert_css "div", class: %w[grid gap-2] do
+      assert_css "div:not([class])", id: "left", text: "The Left", count: 1
+      assert_css "div:not([class])", id: "right", text: "The Right", count: 1
+    end
+  end
+
   test "accessing partial in outer context won't leak state to inner render" do
     render "partial_accessed_in_outer_context"
 


### PR DESCRIPTION
First, add coverage for passing in keyword options from a Partial's call site. In support of that coverage, introduce the
`test/fixtures/_columns.html.erb` partial.

Next, add a test to exercise that partial _without_ call site option overrides. Without the implementation change, that test raises an exception like:

```
Error:
RendererTest#test_render_without_options_from_call_site:
ActionView::Template::Error: undefined method `merge' for nil:NilClass

      @view_context.tag.public_send(meth, @content + arguments.first.to_s, **options.merge(keywords), &block)
                                                                                    ^^^^^^
    test/renderer_test.rb:38:in `block in <class:RendererTest>'
```

The issue is related to the absence of the `@options` instance variable. The cause stems from the `#process_options` post-fix conditional (`unless new_options.empty?`) serving as a guard clause preventing the `@options` variable's declaration.

To resolve the issue, move the `@options ||= Options.new(@view_context)` declaration out of `process_options` and into the `Content` constructor to guarantee that the value is _always_ present.