### PR TITLE
Rewrite README post overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nice_partials [![[version]](https://badge.fury.io/rb/nice_partials.svg)](https://badge.fury.io/rb/nice_partials)  [![[travis]](https://travis-ci.org/andrewculver/nice_partials.svg)](https://travis-ci.org/andrewculver/nice_partials)
+# nice_partials [![[version]](https://badge.fury.io/rb/nice_partials.svg)](https://badge.fury.io/rb/nice_partials)
 
 Nice Partials adds ad-hoc named content areas to Action View partials with a lot of extra power.
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ You can access the inner content lines through what's returned from `yield`:
 <%= yield %> # => "Some content!\n\nYet more content!"
 ```
 
-With Nice Partials, you can call `partial.yield` without arguments and return the same `"Some content!\n\nYet more content!"`.
+With Nice Partials, `partial.yield` returns the same `"Some content!\n\nYet more content!"`.
 
 ### Defining and using well isolated helper methods
 
-To minimize the amount of pollution in the global helper namespace, you can use the shared context object to define helper methods specifically for your partials _within your partial_ like so:
+To minimize the pollution in the global helper namespace, you can use `partial` to define helper methods specifically for your partials _within your partial_ like so:
 
 ```html+erb
 <% partial.helpers do
@@ -198,8 +198,6 @@ Then later in the partial you can use the helper method like so:
 <td><%= partial.reference_to(user) %></td>
 ```
 
-## Development
-
 ### Testing
 
 ```sh
@@ -208,4 +206,4 @@ bundle exec rake test
 
 ## MIT License
 
-Copyright (C) 2020 Andrew Culver <https://bullettrain.co> and Dom Christie <https://domchristie.co.uk>. Released under the MIT license.
+Copyright (C) 2022 Andrew Culver <https://bullettrain.co> and Dom Christie <https://domchristie.co.uk>. Released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -142,14 +142,6 @@ gem "nice_partials"
 
 ## Usage
 
-### When to use Nice Partials
-
-You only need to use Nice Partials when:
-
- - you want to define one or more named content areas in your partial. If you don't have multiple named content areas in your partial, you could just pass your content into the partial using the standard block and `yield` approach.
-
- - you want to specifically isolate your helper methods for a specific partial.
-
 ### Using Nice Partials
 
 ### Accessing the content returned from `yield`

--- a/README.md
+++ b/README.md
@@ -125,6 +125,46 @@ But since sections respond to and leverage `present?`, we can shorten the above 
 
 This way no empty h1 element is rendered.
 
+#### Accessing the content returned via `partial.yield`
+
+To access the inner content lines in the block here, partials have to manually insert a `<%= yield %>` call.
+
+```html+erb
+<%= render "components/card" do %>
+  Some content!
+  Yet more content!
+<% end %>
+```
+
+With Nice Partials, `partial.yield` returns the same content:
+
+```html+erb
+# app/views/components/_card.html.erb
+<%= partial.yield %> # => "Some content!\n\nYet more content!"
+```
+
+#### Defining and using well isolated helper methods
+
+If you want to have helper methods that are available only within your partials, you can call `partial.helpers` directly:
+
+```html+erb
+# app/views/components/_card.html.erb
+<% partial.helpers do
+  # references should be a link if the user can drill down, otherwise just a text label.
+  def reference_to(user)
+    # look! this method has access to the scope of the entire view context and all the other helpers that come with it!
+    if can? :show, user
+      link_to user.name, user
+    else
+      object.name
+    end
+  end
+end %>
+
+# Later in the partial we can use the method:
+<td><%= partial.reference_to(user) %></td>
+```
+
 ## Sponsored By
 
 <a href="https://bullettrain.co" target="_blank">
@@ -156,56 +196,6 @@ Add to your `Gemfile`:
 
 ```ruby
 gem "nice_partials"
-```
-
-## Usage
-
-### Using Nice Partials
-
-### Accessing the content returned from `yield`
-
-In a regular Rails partial:
-
-```html+erb
-<%= render 'components/card' do %>
-  Some content!
-  Yet more content!
-<% end %>
-```
-
-You can access the inner content lines through what's returned from `yield`:
-
-```html+erb
-<%# app/views/components/_card.html.erb %>
-<%= yield %> # => "Some content!\n\nYet more content!"
-```
-
-With Nice Partials, `partial.yield` returns the same `"Some content!\n\nYet more content!"`.
-
-### Defining and using well isolated helper methods
-
-To minimize the pollution in the global helper namespace, you can use `partial` to define helper methods specifically for your partials _within your partial_ like so:
-
-```html+erb
-<% partial.helpers do
-
-  # references should be a link if the user can drill down, otherwise just a text label.
-  def reference_to(user)
-    # look! this method has access to the scope of the entire view context and all the other helpers that come with it!
-    if can? :show, user
-      link_to user.name, user
-    else
-      object.name
-    end
-  end
-
-end %>
-```
-
-Then later in the partial you can use the helper method like so:
-
-```html+erb
-<td><%= partial.reference_to(user) %></td>
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ But the partial can also prepare tag builders that the rendering block can then 
 <% partial.title.yield tag.with_options(class: "text-m4", data: { controller: "title" }) %> # => <h1 class="text-m4" data-controller="title">Title content</h1>
 ```
 
+#### Smoother conditional rendering
+
+In regular Rails partials it's common to see `content_for?` used to conditionally rendering something. With Nice Partials we can do this:
+
+```html+erb
+<% if partial.title? %>
+  <% partial.title.h1 %>
+<% end %>
+```
+
+But since sections respond to and leverage `present?`, we can shorten the above to:
+
+```html+erb
+<% partial.title.presence&.h1 %>
+```
+
+This way no empty h1 element is rendered.
+
 ## Sponsored By
 
 <a href="https://bullettrain.co" target="_blank">


### PR DESCRIPTION
Starts a new README that acknowledges the recent overhaul we've done — and starts from there.

Fixes #59