### PR TITLE
Add test coverage for Partial Helpers

### DIFF
--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -1,0 +1,13 @@
+<%
+  partial.helpers do
+    def upcase(content)
+      content.upcase
+    end
+
+    def squish(content)
+      content.gsub(/\s+/, " ")
+    end
+  end
+%>
+
+<p><%= upcase yield %></p>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -39,6 +39,22 @@ class RendererTest < NicePartials::Test
     end
   end
 
+  test "render partial that declares helper methods" do
+    render "partial_with_helpers" do
+      "upcased"
+    end
+
+    assert_css "p", text: "UPCASED"
+  end
+
+  test "render partial exposes helper methods to callers" do
+    render "partial_with_helpers" do |partial|
+      partial.squish "text with       spaces"
+    end
+
+    assert_css "p", text: "TEXT WITH SPACES"
+  end
+
   test "accessing partial in outer context won't leak state to inner render" do
     render "partial_accessed_in_outer_context"
 


### PR DESCRIPTION
Introduce renderer test coverage to exercise that Partials can declare their own [isolated helper methods][] for use within templates.

[isolated helper methods]: https://github.com/bullet-train-co/nice_partials/tree/v0.1.5#defining-and-using-well-isolated-helper-methods