### PR TITLE
Let `local_assigns` seed content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-* Allow Nice Partials to grab content from `local_assigns`
+* Seed Nice Partials content from `local_assigns`
 
   Previously, the only way to assign content to a Nice Partial was through passing a block:
 
@@ -14,13 +14,13 @@
     <% partial.byline byline %> <%# `byline` comes from the outer `render` call above. %>
   <% end %>
 
-  Now, Nice Partials will automatically use Rails' `local_assigns`, which contain any `locals:` passed to `render`, as a content fallback. So this works:
+  Now, Nice Partials will automatically use Rails' `local_assigns`, which contain any `locals:` passed to `render`, as the seed for content. So this works:
 
   ```erb
   <%= render "card", title: "Hello there", byline: byline %>
   ```
 
-  So the `card` partial is now oblivious to whether its `title` or `byline` were passed as render `locals:` or through the usual assignments in a block.
+  And the `card` partial is now oblivious to whether its `title` or `byline` were passed as render `locals:` or through the usual assignments in a block.
 
   ```erb
   # app/views/_card.html.erb
@@ -32,6 +32,14 @@
   ```erb
   # app/views/_card.html.erb
   <%= partial.title.presence || local_assigns[:title] %> written by <%= partial.byline.presence || local_assigns[:byline] %>
+  ```
+
+  Passing extra content via a block appends:
+
+  ```erb
+  <%= render "card", title: "Hello there" do |partial| %>
+    <% partial.title ", and welcome!" %> # Calling `partial.title` outputs `"Hello there, and welcome!"`
+  <% end %>
   ```
 
 * Add `NicePartials::Partial#slice`

--- a/README.md
+++ b/README.md
@@ -89,12 +89,39 @@ Nice Partials are a lightweight and more Rails-native alternative to [ViewCompon
 
 Having a `partial` object lets us add abstractions that are hard to replicate in standard Rails partials.
 
+### Passing content from the render call
+
+Nice Partials will use Action View's `local_assigns`, which stores any `locals` passed to `render`, as the basis for contents.
+
+Given a partial like
+
+```html+erb
+<%# app/views/components/_card.html.erb %>
+<%= partial.title %> written by <%= partial.byline %>
+```
+
+Can then be used like this:
+
+```html+erb
+<%= render "components/card", title: "Hello there", byline: "Some guy" do |partial| %>
+  <% partial.byline ", who writes stuff" %>
+<% end %>
+```
+
+This will then output "Hello there written by Some guy, who writes stuff"
+
+You can also use `slice` to pass on content from an outer partial:
+
+```html+erb
+<%= render "components/card", partial.slice(:title, :byline) %>
+```
+
 ### Appending content from the view into a section
 
 Nice Partials supports calling any method on `ActionView::Base`, like the helpers shown here, and then have them auto-append to the section.
 
 ```html+erb
-<%= render "components/card", title: "Some Title" do |partial| %>
+<%= render "components/card" do |partial| %>
   <% partial.title.t ".title" %>
   <% partial.body.render "form", tangible_thing: @tangible_thing %>
   <% partial.image.image_tag image_path("example.jpg"), alt: "An example image" %>

--- a/lib/nice_partials/helper.rb
+++ b/lib/nice_partials/helper.rb
@@ -1,6 +1,10 @@
 require_relative "partial"
 
 module NicePartials::Helper
+  def nice_partial_with(local_assigns)
+    NicePartials::Partial.new(self, local_assigns)
+  end
+
   def nice_partial
     NicePartials::Partial.new(self)
   end

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -48,8 +48,9 @@ module NicePartials::RenderingWithAutoContext
 
   # Overrides `ActionView::Helpers::RenderingHelper#render` to push a new `nice_partial`
   # on the stack, so rendering has a fresh `partial` to store content in.
-  def render(*, local_assigns)
-    __partials.prepend nice_partial_with(local_assigns)
+  def render(options = {}, locals = {}, &block)
+    partial_locals = options.is_a?(Hash) ? options[:locals] : locals
+    __partials.prepend nice_partial_with(partial_locals)
     super
   ensure
     __partials.shift

--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -48,8 +48,8 @@ module NicePartials::RenderingWithAutoContext
 
   # Overrides `ActionView::Helpers::RenderingHelper#render` to push a new `nice_partial`
   # on the stack, so rendering has a fresh `partial` to store content in.
-  def render(*)
-    __partials.prepend nice_partial
+  def render(*, local_assigns)
+    __partials.prepend nice_partial_with(local_assigns)
     super
   ensure
     __partials.shift

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -16,8 +16,8 @@ module NicePartials
     #   <%= content.output_buffer %> # => "This line is printed to the `output_buffer`."
     attr_accessor :output_buffer
 
-    def initialize(view_context)
-      @view_context = view_context
+    def initialize(view_context, local_assigns = nil)
+      @view_context, @local_assigns = view_context, local_assigns
     end
 
     def yield(*arguments, &block)
@@ -90,6 +90,10 @@ module NicePartials
       section(...)&.to_s
     end
 
+    def slice(*keys)
+      keys.index_with { content_for _1 }
+    end
+
     def capture(*arguments, &block)
       self.output_buffer = @view_context.capture(*arguments, self, &block)
     end
@@ -97,7 +101,7 @@ module NicePartials
     private
 
     def section_from(name)
-      @sections ||= {} and @sections[name] ||= Section.new(@view_context)
+      @sections ||= {} and @sections[name] ||= Section.new(@view_context, @local_assigns&.dig(name))
     end
 
     def method_missing(meth, *arguments, **keywords, &block)

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -11,7 +11,7 @@ class NicePartials::Partial::Content
 
   def initialize(view_context, content = nil)
     @view_context, @options = view_context, Options.new(view_context)
-    @content = ActiveSupport::SafeBuffer.new << content&.to_s
+    @content = ActiveSupport::SafeBuffer.new and concat content
   end
   delegate :to_s, :present?, to: :@content
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -10,8 +10,8 @@ class NicePartials::Partial::Content
   end
 
   def initialize(view_context, content = nil)
-    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new(content.to_s)
-    @options = Options.new(@view_context)
+    @view_context, @options = view_context, Options.new(view_context)
+    @content = ActiveSupport::SafeBuffer.new << content&.to_s
   end
   delegate :to_s, :present?, to: :@content
 

--- a/lib/nice_partials/partial/content.rb
+++ b/lib/nice_partials/partial/content.rb
@@ -9,8 +9,8 @@ class NicePartials::Partial::Content
     end
   end
 
-  def initialize(view_context)
-    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new
+  def initialize(view_context, content = nil)
+    @view_context, @content = view_context, ActiveSupport::SafeBuffer.new(content.to_s)
     @options = Options.new(@view_context)
   end
   delegate :to_s, :present?, to: :@content

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
   <%= partial.yield :image %>
   <div class="card-body">
-    <h5 class="card-title"><%= title %></h5>
+    <h5 class="card-title"><%= partial.title %></h5>
     <% if partial.body? %>
       <p class="card-text">
         <%# TODO: remove send pending https://github.com/bullet-train-co/nice_partials/pull/54 %>

--- a/test/fixtures/_local_assigns.html.erb
+++ b/test/fixtures/_local_assigns.html.erb
@@ -1,0 +1,3 @@
+<%= partial.title.h1 %>
+<%= partial.byline.span %>
+<%= partial.header %>

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -129,6 +129,13 @@ class NicePartials::PartialTest < NicePartials::Test
     assert_equal "Hello there", outer_partial.title.to_s
   end
 
+  test "slice" do
+    partial = new_partial(locals: { title: "Hello there" })
+    partial.byline "Some guy"
+
+    assert_equal({ title: "Hello there", byline: "Some guy" }, partial.slice(:title, :byline))
+  end
+
   test "helpers don't leak to view" do
     partial = new_partial
     partial.helpers do
@@ -143,7 +150,7 @@ class NicePartials::PartialTest < NicePartials::Test
 
   private
 
-  def new_partial
-    NicePartials::Partial.new view
+  def new_partial(locals: nil)
+    NicePartials::Partial.new(view, locals)
   end
 end

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -123,6 +123,21 @@ class RendererTest < NicePartials::Test
     end
   end
 
+  test "passing local_assigns as content seeds" do
+    byline = "Some guy"
+
+    render "local_assigns", title: "Title", byline: byline, header: tag.h1("Yo") do |partial|
+      partial.byline ", who writes stuff"
+      partial.header " more"
+    end
+
+    assert_css "h1", text: "Title"
+    assert_css "span", text: "Some guy, who writes stuff"
+    assert_match "<h1>Yo</h1> more", rendered
+
+    assert_equal "Some guy", byline # We can't mutate the passed in content.
+  end
+
   test "doesn't clobber Kernel.p" do
     assert_output "\"it's clobbering time\"\n" do
       render("clobberer") { |p| p.content_for :message, "hello from nice partials" }

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -123,7 +123,7 @@ class RendererTest < NicePartials::Test
     end
   end
 
-  test "passing local_assigns as content seeds" do
+  test "passing local_assigns as content seeds with positional render call" do
     byline = "Some guy"
 
     render "local_assigns", title: "Title", byline: byline, header: tag.h1("Yo") do |partial|
@@ -134,6 +134,21 @@ class RendererTest < NicePartials::Test
     assert_css "h1", text: "Title"
     assert_css "span", text: "Some guy, who writes stuff"
     assert_match "<h1>Yo</h1> more", rendered
+
+    assert_equal "Some guy", byline # We can't mutate the passed in content.
+  end
+
+  test "passing local_assigns as content seeds with hash render call" do
+    byline = "Some guy"
+
+    # Action View won't accept passing a block to this render call style, and blankly overrides the passed in `:partial` key
+    # …for some reason.
+    # https://github.com/rails/rails/blob/90a272a1de6f13711943139c4292336dbff19c7c/actionview/lib/action_view/helpers/rendering_helper.rb#L35
+    render partial: "local_assigns", locals: { title: "Title", byline: byline, header: tag.h1("Yo") }
+
+    assert_css "h1", text: "Title"
+    assert_css "span", text: "Some guy"
+    assert_match "<h1>Yo</h1>", rendered
 
     assert_equal "Some guy", byline # We can't mutate the passed in content.
   end


### PR DESCRIPTION
* Seed Nice Partials content from `local_assigns`

Previously, the only way to assign content to a Nice Partial was through passing a block:

```erb
# app/views/posts/show.html.erb
<%= render "posts/post", byline: "Some guy" %>

# app/views/posts/_post.html.erb
<%= render "card" do |partial| %>
  <% partial.title "Hello there" %>
  <% partial.byline byline %> <%# `byline` comes from the outer `render` call above. %>
<% end %>
```

Now, Nice Partials will automatically use Rails' `local_assigns`, which contain any `locals:` passed to `render`, as the seed for content. So this works:

```erb
<%= render "card", title: "Hello there", byline: byline %>
```

And the `card` partial is now oblivious to whether its `title` or `byline` were passed as render `locals:` or through the usual assignments in a block.

```erb
# app/views/_card.html.erb
<%= partial.title %> written by <%= partial.byline %>
```

Previously to get this behavior you'd need to write:

```erb
# app/views/_card.html.erb
<%= partial.title.presence || local_assigns[:title] %> written by <%= partial.byline.presence || local_assigns[:byline] %>
```

Passing extra content via a block appends:

```erb
<%= render "card", title: "Hello there" do |partial| %>
  <% partial.title ", and welcome!" %> # Calling `partial.title` outputs `"Hello there, and welcome!"`
<% end %>
```

* Add `NicePartials::Partial#slice`

Returns a Hash of the passed keys with their contents, useful for passing to other render calls:

```erb
<%= render "card", partial.slice(:title, :byline) %>
```
