### PR TITLE
Test local assigns content seeds support strict locals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
       - checkout
 
       # Install dependencies
+      - run: "gem update --system" # Rails requires a newer version of Rubygems.
       - run: "RAILS_MAIN=true bundle install"
       - run: "bundle clean --force"
       # - run: "yarn install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       # - *wait_for_docker
       - run:
           name: Run unit tests
-          command: bin/test
+          command: RAILS_MAIN=true bin/test
 
   'Local Standard Ruby':
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       # Install dependencies
       - run: "sudo gem update --system" # Rails requires a newer version of Rubygems.
       - run: "RAILS_MAIN=true bundle install"
-      - run: "bundle clean --force"
+      - run: "RAILS_MAIN=true bundle clean --force"
       # - run: "yarn install"
       # - *wait_for_docker
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
       # We run this because the DB might not be available for a while due to a race condition.
       run: dockerize -wait tcp://localhost:5432 -timeout 1m
 jobs:
-  'Local Minitest':
+  'Local Minitest with Rails 7':
     # docker:
     #   - <<: *ruby_node_browsers_docker_image
     #   - <<: *postgres_docker_image
@@ -53,6 +53,25 @@ jobs:
 
       # Install dependencies
       - run: "bundle install"
+      - run: "bundle clean --force"
+      # - run: "yarn install"
+      # - *wait_for_docker
+      - run:
+          name: Run unit tests
+          command: bin/test
+
+  'Local Minitest with Rails main':
+    # docker:
+    #   - <<: *ruby_node_browsers_docker_image
+    #   - <<: *postgres_docker_image
+    #   - image: circleci/redis
+    executor: ruby/default
+    steps:
+      # - browser-tools/install-browser-tools
+      - checkout
+
+      # Install dependencies
+      - run: "RAILS_MAIN=true bundle install"
       - run: "bundle clean --force"
       # - run: "yarn install"
       # - *wait_for_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - checkout
 
       # Install dependencies
-      - run: "gem update --system" # Rails requires a newer version of Rubygems.
+      - run: "sudo gem update --system" # Rails requires a newer version of Rubygems.
       - run: "RAILS_MAIN=true bundle install"
       - run: "bundle clean --force"
       # - run: "yarn install"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ aliases:
       # We run this because the DB might not be available for a while due to a race condition.
       run: dockerize -wait tcp://localhost:5432 -timeout 1m
 jobs:
-  'Local Minitest with Rails 7':
+  'Local Minitest':
     # docker:
     #   - <<: *ruby_node_browsers_docker_image
     #   - <<: *postgres_docker_image
@@ -164,6 +164,7 @@ workflows:
   build:
     jobs:
       - 'Local Minitest'
+      - 'Local Minitest with Rails main'
       # TODO Enable this when we're sure it won't cause a bunch of conflicts on PRs.
       # - 'Local Standard Ruby'
       - 'Starter Repo Minitest'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
@@ -6,6 +7,11 @@ gem "minitest"
 gem "rake"
 gem "irb"
 
+if ENV["RAILS_MAIN"]
+  gem "rails", github: "rails/rails", branch: "main"
+else
+  gem "rails"
+end
+
 gem "view_component"
-gem "rails"
 gem "capybara"

--- a/test/fixtures/_strict_locals.html.erb
+++ b/test/fixtures/_strict_locals.html.erb
@@ -1,0 +1,4 @@
+<%# locals: (byline:, header:, title: "Title") %>
+<%= partial.title.h1 %>
+<%= partial.byline.span %>
+<%= partial.header %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -139,7 +139,7 @@ class RendererTest < NicePartials::Test
   end
 
   test "passing local_assigns as content seeds with hash render call" do
-    byline = "Some guy"
+    byline = "Some person"
 
     # Action View won't accept passing a block to this render call style, and blankly overrides the passed in `:partial` key
     # …for some reason.
@@ -147,10 +147,27 @@ class RendererTest < NicePartials::Test
     render partial: "local_assigns", locals: { title: "Title", byline: byline, header: tag.h1("Yo") }
 
     assert_css "h1", text: "Title"
-    assert_css "span", text: "Some guy"
+    assert_css "span", text: "Some person"
     assert_match "<h1>Yo</h1>", rendered
 
-    assert_equal "Some guy", byline # We can't mutate the passed in content.
+    assert_equal "Some person", byline # We can't mutate the passed in content.
+  end
+
+  test "passing local_assigns as content seeds with hash render call works with strict template locals" do
+    skip "strict locals aren't supported yet" unless ActionView.version.to_s >= "7.1"
+
+    byline = "Some person"
+
+    # Action View won't accept passing a block to this render call style, and blankly overrides the passed in `:partial` key
+    # …for some reason.
+    # https://github.com/rails/rails/blob/90a272a1de6f13711943139c4292336dbff19c7c/actionview/lib/action_view/helpers/rendering_helper.rb#L35
+    render partial: "strict_locals", locals: { byline: byline, header: tag.h1("Yo") }
+
+    assert_no_css "h1", text: "Title" # We can only extract values from the passed `locals` above and not any defaults set in the local scope of the partial itself.
+    assert_css "span", text: "Some person"
+    assert_match "<h1>Yo</h1>", rendered
+
+    assert_equal "Some person", byline # We can't mutate the passed in content.
   end
 
   test "doesn't clobber Kernel.p" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,8 @@ ViewComponent::Base.config = ViewComponent::Config.new
 class NicePartials::Test < ActionView::TestCase
   include Capybara::Minitest::Assertions
 
-  TestController.view_paths << "test/fixtures/(special)" << "test/fixtures"
+  TestController.prepend_view_path "test/fixtures"
+  TestController.prepend_view_path "test/fixtures/(special)"
 
   private
 


### PR DESCRIPTION
Note: this also sets us up to test with the Rails main branch.

If any strict local provides a default we can't sift it as a content seed.

They'll have to be provided as render locals:

```ruby
render "partial", some_local_variable: "Hello"
```

This would be the same for any local variable, e.g.:

```erb
<% locals: (some_local_variable: "Hello") %>
<% some_local_variable = "Hello" %> # This and the line above are equivalent because…
<%= partial.some_local_variable %> # We can't access the local variable from the outer scope in the method scope.
```

I tried several routes of `binding` trickery to get access to the outer scope, but I couldn't find anything.