### PR TITLE
Prevent view instance variables from leaking into render calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## CHANGELOG
 
+* Add option to prevent instance variables leaking into partials
+
+  Due to the way Action View's rendering works any instance variable on the template,
+  usually copied over from a controller, will leak into any partial renders like so:
+
+  ```erb
+  # This should've been `render "post", post: @post`
+  <%= render "post" %>
+
+  # _post.html.erb
+  <%= @post.title %> # The partial relies on the @post instance variable, but it should've used a local variable
+  ```
+
+  Now, if apps add an initializer like this:
+
+  ```ruby
+  # config/initializers/nice_partials.rb
+  NicePartials.prevent_instance_variable_leaks = Rails.env.development? || Rails.env.test?
+  ```
+
+  NicePartials will clear out any instance variables during a `render` call and reset them afterwards.
+
+  Note: this shouldn't be enabled in production. Catch the issues in development or test instead.
+
 * Fix rendering with special characters in a view path.
 
   Ref: https://github.com/bullet-train-co/nice_partials/pull/70

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ But if we render something, then due to a quirk of how Action View's rendering w
 <%= @post.title %> # This works because the `@post` variable has leaked, but it shouldn't have.
 ```
 
-This may seem fine for this example, but it can get hairy with complex that may have various uses of instance variables and local variables.
+This may seem fine for this example, but it can get hairy with complex partials that may have various uses of instance variables and local variables.
 
 With `NicePartials.prevent_instance_variable_leaks` enabled, we're forced to do:
 

--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -3,6 +3,9 @@
 require_relative "nice_partials/version"
 
 module NicePartials
+  singleton_class.attr_accessor :prevent_instance_variable_leaks
+  singleton_class.alias_method :prevent_instance_variable_leaks?, :prevent_instance_variable_leaks
+
   def self.locale_prefix_from(lookup_context, block)
     partial_location = block.source_location.first.dup
     lookup_context.view_paths.each { partial_location.delete_prefix!(_1.path)&.delete_prefix!("/") }

--- a/test/fixtures/renderer/instance_variable_leak_prevention/_with_ivar.html.erb
+++ b/test/fixtures/renderer/instance_variable_leak_prevention/_with_ivar.html.erb
@@ -1,0 +1,1 @@
+<%= @title.upcase %>

--- a/test/fixtures/renderer/instance_variable_leak_prevention/_without_ivar.html.erb
+++ b/test/fixtures/renderer/instance_variable_leak_prevention/_without_ivar.html.erb
@@ -1,0 +1,1 @@
+<%= title.upcase %>

--- a/test/renderer/instance_variable_leak_prevention_test.rb
+++ b/test/renderer/instance_variable_leak_prevention_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+module Renderer; end
+
+class Renderer::InstanceVariableLeakPreventionTest < NicePartials::Test
+  setup { view.assign title: "ivar title" }
+
+  test "instance variables won't leak into partial" do
+    error = assert_raises ActionView::Template::Error do
+      render "renderer/instance_variable_leak_prevention/with_ivar"
+    end
+
+    assert_empty rendered
+    assert_equal "ivar title", view.instance_variable_get(:@title)
+    assert_equal "undefined method `upcase' for nil:NilClass", error.message
+  end
+
+  test "local variables work" do
+    render "renderer/instance_variable_leak_prevention/without_ivar", title: "local title"
+
+    assert_text "LOCAL TITLE"
+    assert_equal "ivar title", view.instance_variable_get(:@title)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,8 @@ require "capybara/minitest"
 require "view_component"
 require "nice_partials"
 
+NicePartials.prevent_instance_variable_leaks = true
+
 # Ensure we assign the default configs, so `view_component_path` is set.
 ViewComponent::Base.config = ViewComponent::Config.new
 


### PR DESCRIPTION
Due to the way Action View's rendering works any instance variable on the template, usually copied over from a controller, will leak into any partial renders like so:

```erb
<%# app/views/posts/index.html.erb %>
<%= render "post" %>

<%# app/views/posts/_post.html.erb %>
<%= @post.title %> # The partial relies on the @post instance variable, but it should've used a local variable
```

Now, if apps add an initializer like this:

```ruby
NicePartials.prevent_instance_variable_leaks = Rails.env.development? || Rails.env.test?
```

NicePartials will clear out any instance variables during a `render` call and reset them afterwards.

Note: this shouldn't be enabled in production. Catch the issues in development or test instead.