### PR TITLE
Failing test for yielding `label` block

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -95,11 +95,7 @@ module NicePartials
     end
 
     def method_missing(meth, *arguments, **keywords, &block)
-      if @view_context.respond_to?(meth)
-        @view_context.public_send(meth, *arguments, **keywords, &block)
-      else
-        define_accessor meth and public_send(meth, *arguments, **keywords, &block)
-      end
+      define_accessor meth and public_send(meth, *arguments, **keywords, &block)
     end
 
     def define_accessor(name)

--- a/test/fixtures/_yield_label.html.erb
+++ b/test/fixtures/_yield_label.html.erb
@@ -1,0 +1,1 @@
+<%= partial.label.yield %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -15,6 +15,14 @@ class RendererTest < NicePartials::Test
     assert_css("img") { assert_equal "https://example.com/image.jpg", _1["src"] }
   end
 
+  test "render partial can yield block named label" do
+    render "yield_label" do |partial|
+      partial.label "Label"
+    end
+
+    assert_text "Label"
+  end
+
   test "render with options from call site" do
     render "columns" do |partial|
       partial.left "The Left", class: "left-column"


### PR DESCRIPTION
When yielding a block named `label` (via `partial.label.yield`), an argument error is raised.

```
Error:
RendererTest#test_render_partial_can_yield_block_named_label:
ArgumentError: wrong number of arguments (given 1, expected 2..4)
    test/renderer_test.rb:20:in `block (2 levels) in <class:RendererTest>'
    test/renderer_test.rb:19:in `block in <class:RendererTest>'
```