### PR TITLE
Restructure helpers to use a cleanroom object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ### 0.9.2
 
-* Fixed: view methods don't clobber section names
+* Changed: view methods don't clobber section names
 
   Previously, we'd eagerly delegate to the view context so if the view had a `label` method, `partial.label` would call the view's `label` instead of making a `label` section.
 
-  This was to support `partial.helpers` having direct access to the view context.
-  `partial.helpers`
+  This was to support `partial.helpers` but we've changed the implementation to support the above. `partial.helpers` still works the same too.
 
-* Fixed: `partial.helpers` no longer automatically calls `partial` methods
+* Changed: `partial.helpers` no longer automatically calls `partial` methods
 
   Previously, if a user defined a partial helper like this:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## CHANGELOG
 
+### 0.9.2
+
+* Fixed: view methods don't clobber section names
+
+  Previously, we'd eagerly delegate to the view context so if the view had a `label` method, `partial.label` would call the view's `label` instead of making a `label` section.
+
+  This was to support `partial.helpers` having direct access to the view context.
+  `partial.helpers`
+
+* Fixed: `partial.helpers` no longer automatically calls `partial` methods
+
+  Previously, if a user defined a partial helper like this:
+
+  ```ruby
+  partial.helpers do
+    def some_helper
+      some_section
+    end
+  end
+  ```
+
+  If `some_section` wasn't a view method, it would automatically call `partial.some_section`
+  thereby adding a new content section to the partial.
+
+  Now `partial.helpers` behaves exactly like view helpers — making it easier to copy code directly when migrating — so users would have to explicitly call `partial.some_section`.
+
 ### 0.9.1
 
 * Fix Ruby 2.7 compatibility

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -110,12 +110,7 @@ module NicePartials
       @helpers_context ||= Helpers.new(@view_context)
     end
 
-    class Helpers
-      def initialize(view_context)
-        @view_context = view_context
-      end
-      delegate_missing_to :@view_context
-
+    class Helpers < SimpleDelegator
       def self.method_added(name)
         super
         NicePartials::Partial.delegate name, to: :helpers_context

--- a/test/fixtures/_yield_label.html.erb
+++ b/test/fixtures/_yield_label.html.erb
@@ -1,0 +1,1 @@
+<%= partial.label.yield %>

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -15,6 +15,14 @@ class RendererTest < NicePartials::Test
     assert_css("img") { assert_equal "https://example.com/image.jpg", _1["src"] }
   end
 
+  test "render partial can yield block named label" do
+    render "yield_label" do |partial|
+      partial.label "Label"
+    end
+
+    assert_text "Label"
+  end
+
   test "render with options from call site" do
     render "columns" do |partial|
       partial.left "The Left", class: "left-column"


### PR DESCRIPTION
Fixes #76

This should make it such that you can do `partial.label.yield` without clashing with a view context `label` method. In case users define a custom helper method, they can still call them directly like before.

Not sure if I like this. I can't figure if it's just exposing complexity that was already there though?

cc @seanpdoyle