### PR TITLE
Add fallback to ease showing default content

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ Nice Partials supports calling any method on `ActionView::Base`, like the helper
 <% partial.byline t("custom.key") %>
 ```
 
+### Fallback to default content if nothing's been set
+
+```html+erb
+<%= partial.header.fallback "Default Header" %>
+<%= partial.header.fallback do %>
+  <h1>Default Header</h1>
+<% end %>
+```
+
+Note: this doesn't write anything to the section.
+
 ### Capturing options in the rendering block and building HTML tags in the partial
 
 You can pass keyword options to a writer method and they'll be auto-added to `partial.x.options`, like so:

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -43,6 +43,10 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
     chunks.present? || super
   end
 
+  def fallback(content = nil, &block)
+    presence || content || (@view_context.capture(&block) if block_given?)
+  end
+
   undef_method :p # Remove Kernel.p here to pipe through method_missing and hit tag proxy.
 
   # Implements our proxying to the `@view_context` or `@view_context.tag`.

--- a/lib/nice_partials/partial/section.rb
+++ b/lib/nice_partials/partial/section.rb
@@ -34,6 +34,21 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
     present? ? self : Empty.new(self)
   end
 
+  # Allows adding a default fallback when there's been no content provided.
+  #
+  #   <%= partial.header.fallback "Default header" %>
+  #
+  #   <%= partial.header.fallback do %>
+  #    <h1>Default Header</h1>
+  #   <% end %>
+  #
+  #   Can also output a tag when there's no content:
+  #   <%= partial.header.fallback.h1 "Default header" %>
+  def fallback(content = nil, &block)
+    # TODO: Add a proxy that returns `self` when content is present and e.g. `h1` is called.
+    presence || content || (@view_context.capture(&block) if block_given?) || @view_context.tag
+  end
+
   def yield(*arguments)
     chunks.each { append @view_context.capture(*arguments, &_1) }
     self
@@ -41,10 +56,6 @@ class NicePartials::Partial::Section < NicePartials::Partial::Content
 
   def present?
     chunks.present? || super
-  end
-
-  def fallback(content = nil, &block)
-    presence || content || (@view_context.capture(&block) if block_given?)
   end
 
   undef_method :p # Remove Kernel.p here to pipe through method_missing and hit tag proxy.


### PR DESCRIPTION
Just a quick idea to provide ease providing fallback content, in case a section is optional.

Before:

```erb
<% if partial.header? %>
  <%= partial.header %>
<% else %>
  <h1>Default Header</h1>
<% end %>
```

After:

```erb
<%= partial.header.fallback do %>
  <h1>Default Header</h1>
<% end %>
```

Or the one liner in this simple case `<%= partial.header.fallback tag.h1("Default Header") %>`.

I haven't wrapped this up and I'm gonna sleep on this if any knits or issues pop up.