### PR TITLE
Fix backwardscompatibility: ensure content_for returns nil when empty

### DIFF
--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -75,7 +75,7 @@ module NicePartials
     alias content_for? section?
 
     def content_for(...)
-      section(...)&.to_s
+      section(...).presence&.to_s
     end
 
     def slice(*keys)

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -69,6 +69,8 @@ class NicePartials::PartialTest < NicePartials::Test
 
   test "content_for returns content itself and not section object" do
     partial = new_partial
+    assert_nil partial.content_for(:body)
+
     partial.body "some content"
 
     assert_nil partial.content_for(:body, ", yet more"), "content_for must return nil when writing content"


### PR DESCRIPTION
`content_for` is meant to return nil when nothing's been written to the named buffer and not an empty string. This mirrors Rails' `content_for`.