### PR TITLE
Accept symbol keys to the t() / translate function

### DIFF
--- a/lib/nice_partials/monkey_patch.rb
+++ b/lib/nice_partials/monkey_patch.rb
@@ -8,7 +8,7 @@ module NicePartials::RenderingWithLocalePrefix
   end
 
   def t(key, options = {})
-    if (prefix = @_nice_partials_t_prefix) && key.first == '.'
+    if (prefix = @_nice_partials_t_prefix) && key.to_s.first == '.'
       key = "#{prefix}#{key}"
     end
 

--- a/test/fixtures/translations/_nice_partials_translated_symbol.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated_symbol.html.erb
@@ -1,0 +1,3 @@
+<%= render("basic") do |partial| %>
+  <%= partial.message.t :message %>
+<% end %>

--- a/test/renderer/translation_test.rb
+++ b/test/renderer/translation_test.rb
@@ -7,6 +7,7 @@ class Renderer::TranslationTest < NicePartials::Test
     I18n.backend.store_translations "en", translations: {
       translated: { message: "message" },
       nice_partials_translated: { message: "nice_partials" },
+      nice_partials_translated_symbol: { message: "nice_partials" },
       t: { title: "title key content", header: "header key content" },
       special_nice_partials_translated: { message: "message content" }
     }
@@ -23,6 +24,12 @@ class Renderer::TranslationTest < NicePartials::Test
 
   test "translations insert prefix from originating partial" do
     render "translations/nice_partials_translated"
+
+    assert_text "nice_partials"
+  end
+
+  test "translations insert prefix from originating partial when translation key is a symbol" do
+    render "translations/nice_partials_translated_symbol"
 
     assert_text "nice_partials"
   end


### PR DESCRIPTION
Hi, We just saw an issue with nice_partials and a Rails Engine, specifically good_job attempting to render an icon with a scoped translation where the translation key being passed was a symbol.

[See their call here](https://github.com/bensheldon/good_job/blob/616e0708f10868375dcf8a39ba569069dbf9e73f/app/helpers/good_job/application_helper.rb#L45)


So i've made a change to support it.
Unclear if symbol keys should be entirely ignored for prefixing as I assume it will be rare to pass `t(:".foo")`

I built a test app that hopefully showcases the issue.
I also added a test_case but I'm unclear on how to run the tests for the gem; The README says `bundle exec rake test` but `bundle exec rake -T` lists no task called test.

<details>
<summary>Minimal App Test Case</summary>
run with

```
$ rbenv local 3.1.2
$ ruby main.rb
```
 
```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  ruby '3.1.2'

  gem 'rails', '~> 6.1.6'
  gem 'nice_partials', '~> 0.9.1'
  gem 'puma', '~> 4.3.12'

  # gem 'pry', '~> 0.13.1'
  # gem 'pry-rails', '~> 0.3.9'
  # gem 'pry-byebug', '~> 3.9.0'
end

require "action_controller/railtie"

class App < Rails::Application
  routes.append do
    get "/" => "home#index"
  end

  config.consider_all_requests_local = true
  config.eager_load = false
end


INDEX = <<~FOO
  <%= render('partial') do %>
    <%= t(:foo) %>
  <% end %>
FOO

PARTIAL = <<~FOO
  something
FOO

class HomeController < ActionController::Base
  def index; end
end

FileUtils.mkdir_p("#{Rails.root}/app/views/home")
File.write("#{Rails.root}/app/views/home/index.html.erb", INDEX)
File.write("#{Rails.root}/app/views/home/_partial.html.erb", PARTIAL)

App.initialize!

Rack::Server.new(app: App, Port: 3001).start
```

</details>