### PR TITLE
Fix predicates not respecting local_assigns content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## CHANGELOG
 
+### 0.9.3
+
+* Fixed: section predicates not respecting `local_assigns` content
+
+  Previously, when doing something like this:
+
+  ```erb
+  <%= render "card", title: "Hello there" %>
+  ```
+
+  If the inner card partial had this,
+
+  ```erb
+  <% if partial.title? %>
+    <%= partial.title %>
+  <% end %>
+  ```
+
+  The `title?` predicate would fail, because it didn't look up content from the passed `local_assigns`. Now it does.
+
 ### 0.9.2
 
 * Changed: view methods don't clobber section names

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -70,7 +70,7 @@ module NicePartials
     end
 
     def section?(name)
-      @sections&.dig(name).present?
+      section_from(name).present?
     end
     alias content_for? section?
 

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -138,6 +138,12 @@ class NicePartials::PartialTest < NicePartials::Test
     assert_equal({ title: "Hello there", byline: "Some guy" }, partial.slice(:title, :byline))
   end
 
+  test "predicates respects locals" do
+    partial = new_partial(locals: { title: "Hello there" })
+    assert partial.title?
+    assert_equal "Hello there", partial.title.to_s
+  end
+
   test "helpers don't leak to view" do
     partial = new_partial
     partial.helpers do


### PR DESCRIPTION
When passing local_assigns onto a Partial, our `partial.title` helpers would correctly look up content from local_assigns. But our `partial.title?` predicate helper would not.

This fixes that.