### PR TITLE
Fix t prefixes not being assigned properly

### DIFF
--- a/lib/nice_partials.rb
+++ b/lib/nice_partials.rb
@@ -3,11 +3,6 @@
 require_relative "nice_partials/version"
 
 module NicePartials
-  def self.locale_prefix_from(lookup_context, block)
-    partial_location = block.source_location.first.dup
-    lookup_context.view_paths.each { partial_location.delete_prefix!(_1.path)&.delete_prefix!("/") }
-    partial_location.split('.').first.gsub('/_', '/').gsub('/', '.')
-  end
 end
 
 ActiveSupport.on_load :action_view do

--- a/test/fixtures/translations/_nice_partials_translated.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated.html.erb
@@ -1,3 +1,3 @@
-<%= render("basic") do |partial| %>
-  <%= partial.message.t ".message" %>
+<%= render "basic" do %>
+  <% _1.message.t ".message" %>
 <% end %>

--- a/test/fixtures/translations/_nice_partials_translated_nested.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated_nested.html.erb
@@ -1,0 +1,6 @@
+<%= render "basic" do %>
+  <% _1.message render("translations/translated") %>
+  <% _1.message do %>
+    <%= render "translations/translated" %>
+  <% end %>
+<% end %>

--- a/test/renderer/translation_test.rb
+++ b/test/renderer/translation_test.rb
@@ -34,6 +34,12 @@ class Renderer::TranslationTest < NicePartials::Test
     assert_text "nice_partials"
   end
 
+  test "translations nested" do
+    render "translations/nice_partials_translated_nested"
+
+    assert_text "message\n    message\n"
+  end
+
   test "translations key lookup handles special characters" do
     render "translations/special_nice_partials_translated"
 


### PR DESCRIPTION
This fixes two changes I made to our t-prefixes that broke things:

1. overriding `ActionView::Base#capture` meant that we'd fire on helper calls too — and extract from their block location.
2. overriding `ActionView::Base#render` instead of `ActionView::PartialRenderer#render` meant that we wouldn't accurately assign the prefix to each render in a collection.

Note: we're leveraging Rails 6.1+'s `@current_template.virtual_path` to avoid needing to muck with block source_locations or view_paths, Rails has already figured that out for us.