### PR TITLE
Expose `local_assigns` to Partial Helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## CHANGELOG
 
+* Feature: partial helpers can access `local_assigns` values
+
+  ```html+erb
+  <%# app/views/articles/show.html.erb %>
+  <% render "section", id: "an_article" do |section| %>
+    <%= tag.h1 "An Article", id: section.labelledby %>
+  <% end %>
+
+  <%# app/views/application/_section.html.erb %>
+  <%
+    partial.helpers do
+      def labelledby
+        if (id = local_assigns[:id])
+          "#{id}_label"
+        end
+      end
+
+      def aria
+        local_assigns.fetch(:aria, {}).with_defaults(labelledby:)
+      end
+    end
+  %>
+
+  <%= tag.section partial.yield, id:, aria: partial.aria %>
+  ```
+
 ### 0.9.4
 
 * Feature: declare contents via `required` and `optional`
@@ -21,7 +47,7 @@
 
   <div><%= partial.body.required %></div> <%# Raises when this line is hit if no content has been provided %>
   ```
-  
+
   See the README for more.
 
 ### 0.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 ## CHANGELOG
 
-* Feature: partial helpers can access `local_assigns` values
+* Feature: partial's expose `local_assigns` + `locals` alias
+
+  ```html+erb
+  <%# app/views/articles/show.html.erb %>
+  <%= render "section", id: "an_article" %>
+
+  <%# app/views/application/_section.html.erb %>
+  <%# We can access the passed `id:` like this: %>
+  <% partial.local_assigns[:id] %>
+  <% partial.locals[:id] %>
+  ```
+
+  Note: this is equal to the default partial local variable of `local_assigns`, but it becomes more useful with the next feature below.
+
+* Feature: partial helpers can access `partial`
 
   ```html+erb
   <%# app/views/articles/show.html.erb %>
@@ -11,14 +25,12 @@
   <%# app/views/application/_section.html.erb %>
   <%
     partial.helpers do
-      def labelledby
-        if (id = local_assigns[:id])
-          "#{id}_label"
-        end
+      def aria
+        partial.locals.fetch(:aria, {}).with_defaults(labelledby:)
       end
 
-      def aria
-        local_assigns.fetch(:aria, {}).with_defaults(labelledby:)
+      def labelledby
+        id = partial.locals[:id] and "#{id}_label"
       end
     end
   %>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -4,6 +4,9 @@ module NicePartials
     autoload :Section, "nice_partials/partial/section"
     autoload :Stack, "nice_partials/partial/stack"
 
+    attr_reader :local_assigns
+    alias_method :locals, :local_assigns
+
     def initialize(view_context, local_assigns = nil)
       @view_context, @local_assigns = view_context, local_assigns
     end
@@ -107,23 +110,23 @@ module NicePartials
     end
 
     def helpers_context
-      @helpers_context ||= Helpers.new(@view_context, @local_assigns)
+      @helpers_context ||= Helpers.new(@view_context, self)
     end
 
     class Helpers < SimpleDelegator
-      attr_reader :local_assigns
-
       def self.method_added(name)
         super
 
-        unless name == :initialize
+        unless name == :initialize || name == :partial
           NicePartials::Partial.delegate name, to: :helpers_context
         end
       end
 
-      def initialize(view_context, local_assigns)
+      attr_reader :partial
+
+      def initialize(view_context, partial)
         super(view_context)
-        @local_assigns = local_assigns
+        @partial = partial
       end
     end
   end

--- a/lib/nice_partials/partial.rb
+++ b/lib/nice_partials/partial.rb
@@ -107,13 +107,23 @@ module NicePartials
     end
 
     def helpers_context
-      @helpers_context ||= Helpers.new(@view_context)
+      @helpers_context ||= Helpers.new(@view_context, @local_assigns)
     end
 
     class Helpers < SimpleDelegator
+      attr_reader :local_assigns
+
       def self.method_added(name)
         super
-        NicePartials::Partial.delegate name, to: :helpers_context
+
+        unless name == :initialize
+          NicePartials::Partial.delegate name, to: :helpers_context
+        end
+      end
+
+      def initialize(view_context, local_assigns)
+        super(view_context)
+        @local_assigns = local_assigns
       end
     end
   end

--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -9,7 +9,7 @@
     end
 
     def upcase_foo
-      local_assigns[:foo].upcase
+      partial.locals[:foo].upcase
     end
   end
 %>

--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -7,6 +7,10 @@
     def squish(content)
       content.gsub(/\s+/, " ")
     end
+
+    def upcase_foo
+      local_assigns[:foo].upcase
+    end
   end
 %>
 

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -164,6 +164,17 @@ class NicePartials::PartialTest < NicePartials::Test
     assert_equal "Hello there", partial.title.to_s
   end
 
+  test "helpers can access local_assigns" do
+    partial = new_partial(locals: {foo: "bar"})
+    partial.helpers do
+      def upcase_foo
+        local_assigns[:foo].upcase
+      end
+    end
+
+    assert_equal "BAR", partial.upcase_foo
+  end
+
   test "helpers don't leak to view" do
     partial = new_partial
     partial.helpers do

--- a/test/nice_partials/partial_test.rb
+++ b/test/nice_partials/partial_test.rb
@@ -164,11 +164,23 @@ class NicePartials::PartialTest < NicePartials::Test
     assert_equal "Hello there", partial.title.to_s
   end
 
+  test "helpers can access partial" do
+    partial = new_partial(locals: {foo: "bar"})
+    partial.helpers do
+      def fill_in_body
+        partial.body "body content"
+      end
+    end
+
+    partial.fill_in_body
+    assert_equal "body content", partial.body.to_s
+  end
+
   test "helpers can access local_assigns" do
     partial = new_partial(locals: {foo: "bar"})
     partial.helpers do
       def upcase_foo
-        local_assigns[:foo].upcase
+        partial.local_assigns[:foo].upcase
       end
     end
 
@@ -185,6 +197,10 @@ class NicePartials::PartialTest < NicePartials::Test
 
     assert_equal "YO", partial.upcase("yo")
     assert_not_respond_to view, :upcase
+  end
+
+  test "locals" do
+    assert_equal({foo: "bar"}, new_partial(locals: {foo: "bar"}).locals)
   end
 
   private

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -63,6 +63,14 @@ class RendererTest < NicePartials::Test
     assert_css "p", text: "TEXT WITH SPACES"
   end
 
+  test "render partial helper methods can access local_assigns" do
+    render "partial_with_helpers", foo: "bar" do |partial|
+      partial.upcase_foo
+    end
+
+    assert_css "p", text: "BAR"
+  end
+
   test "accessing partial in outer context won't leak state to inner render" do
     render "partial_accessed_in_outer_context"
 


### PR DESCRIPTION
Prior to this commit, helper methods defined in a partial were unable to
access the local variable state. By granting access to
`partial.local_assigns`, we provide another avenue for abstraction:

```html+erb
<%# app/views/articles/show.html.erb %>
<% render "section", id: "an_article" do |section| %>
  <%= tag.h1 "An Article", id: section.labelledby %>
<% end %>

<%# app/views/application/_section.html.erb %>
<%
  partial.helpers do
    def labelledby
      if (id = local_assigns[:id])
        "#{id}_label"
      end
    end

    def aria
      local_assigns.fetch(:aria, {}).with_defaults(labelledby:)
    end
  end
%>

<%= tag.section partial.yield, id:, aria: partial.aria %>
```