### PR TITLE
BRB templates: be right back to ERB

### DIFF
--- a/test/fixtures/(special)/translations/_special_nice_partials_translated.html.erb
+++ b/test/fixtures/(special)/translations/_special_nice_partials_translated.html.erb
@@ -1,3 +1,3 @@
-<%= render("basic") do |partial| %>
-  <%= partial.message.t ".message" %>
-<% end %>
+\= render("basic") do |partial|
+  \= partial.message.t ".message"
+\end

--- a/test/fixtures/_basic.html.erb
+++ b/test/fixtures/_basic.html.erb
@@ -1,1 +1,1 @@
-<%= partial.yield :message %>
+\= partial.yield :message

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -1,11 +1,11 @@
 <div class="card">
-  <%= partial.yield :image %>
+  \= partial.yield :image
   <div class="card-body">
-    <h5 class="card-title"><%= partial.title %></h5>
-    <% if partial.body? %>
+    <h5 class="card-title">\= partial.title</h5>
+    \if partial.body?
       <p class="card-text">
-        <%= partial.body.yield tag.with_options(class: "text-bold") %>
+        \= partial.body.yield tag.with_options(class: "text-bold")
       </p>
-    <% end %>
+    \end
   </div>
 </div>

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -11,8 +11,8 @@
 </div>
 
 \# Just some test data
-\ post = Struct.new(:title, :active?, :options).new("hello", true, { data: { controller: "post" }, aria: { role: "list" } })
-\ partial.body class: ["super", active: post.active?], data: { controller: "cool" }
+\post = Struct.new(:title, :active?, :options).new("hello", true, { data: { controller: "post" }, aria: { role: "list" } })
+\partial.body class: ["super", active: post.active?], data: { controller: "cool" }
 
 <h1 \class(active: post.active?)>\= post.title</h1>
 
@@ -20,7 +20,13 @@
 <span \attributes(post.options)></span>
 <span \p(post.options)></span> \# or just?
 
-\# Can't place data-list-value="yo" after sigils, and can't have multi sigils yet.
+\# Can't place data-list-value="yo" after sigils, and can't have multi sigils yet. \# Fix comments not seeking to eol to close.
 \lorem() \# Fix needing () on this sigil
 <span data-list-value="yo" \data(post.options[:data])></span>
 <span data-list-value="yo" \data({ controller: "list" })>\lorem()</span>
+
+\= post.title
+<h1>\= post.title</h1>
+<h1 \data(post.options[:data])></h1>
+\post.title.match? /\w+/
+<h1 \p(post.options) \attributes(post.options) data-controller="title"></h1> \# Fix no space before data-controller

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -9,3 +9,17 @@
     \end
   </div>
 </div>
+
+\# Just some test data
+\ post = Struct.new(:title, :active?, :options).new("hello", true, { data: { controller: "post" }, aria: { role: "list" } })
+\ partial.body class: ["super", active: post.active?], data: { controller: "cool" }
+
+<h1 \class(active: post.active?)>\= post.title</h1>
+
+<span \= partial.body.options></span>
+<span \attributes(post.options)></span>
+<span \p(post.options)></span> \# or just?
+
+\# Can't place data-list-value="yo" after sigils, and can't have multi sigils yet.
+<span data-list-value="yo" \data(post.options[:data])></span>
+<span data-list-value="yo" \data({ controller: "list" })></span>

--- a/test/fixtures/_card.html.erb
+++ b/test/fixtures/_card.html.erb
@@ -21,5 +21,6 @@
 <span \p(post.options)></span> \# or just?
 
 \# Can't place data-list-value="yo" after sigils, and can't have multi sigils yet.
+\lorem() \# Fix needing () on this sigil
 <span data-list-value="yo" \data(post.options[:data])></span>
-<span data-list-value="yo" \data({ controller: "list" })></span>
+<span data-list-value="yo" \data({ controller: "list" })>\lorem()</span>

--- a/test/fixtures/_clobberer.html.erb
+++ b/test/fixtures/_clobberer.html.erb
@@ -1,3 +1,3 @@
-<% p "it's clobbering time" %>
-<%# TODO: Remove this file once `p` has been removed post deprecation, but don't change it yet. %>
-<%= p.yield :message %>
+\p "it's clobbering time"
+\# TODO: Remove this file once `p` has been removed post deprecation, but don't change it yet.
+\= p.yield :message

--- a/test/fixtures/_columns.html.erb
+++ b/test/fixtures/_columns.html.erb
@@ -1,4 +1,4 @@
 <div class="grid gap-2">
-  <%= partial.left.div id: "left" %>
-  <%= partial.right.div id: "right" %>
+  \= partial.left.div id: "left"
+  \= partial.right.div id: "right"
 </div>

--- a/test/fixtures/_local_assigns.html.erb
+++ b/test/fixtures/_local_assigns.html.erb
@@ -1,3 +1,3 @@
-<%= partial.title.h1 %>
-<%= partial.byline.span %>
-<%= partial.header %>
+\= partial.title.h1
+\= partial.byline.span
+\= partial.header

--- a/test/fixtures/_partial_accessed_in_outer_context.html.erb
+++ b/test/fixtures/_partial_accessed_in_outer_context.html.erb
@@ -1,11 +1,11 @@
-<% partial.content_for :original_message, "hello" %>
+\partial.content_for :original_message, "hello"
 
-<%= render "basic" do |cp| %>
-  <% cp.content_for :message, partial.content_for(:original_message) %>
-<% end %>
+\= render "basic" do |cp|
+  \cp.content_for :message, partial.content_for(:original_message)
+\end
 
-<%= render "basic" do |cp| %>
-  <% cp.content_for :message, "goodbye" %>
-<% end %>
+\= render "basic" do |cp|
+  \cp.content_for :message, "goodbye"
+\end
 
-<span><%= partial.content_for :message %></span>
+<span>\= partial.content_for :message</span>

--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -1,17 +1,15 @@
-<%
-  partial.helpers do
-    def upcase(content)
-      content.upcase
-    end
-
-    def squish(content)
-      content.gsub(/\s+/, " ")
-    end
-
-    def upcase_foo
-      partial.locals[:foo].upcase
-    end
-  end
-%>
+\partial.helpers do
+\  def upcase(content)
+\    content.upcase
+\  end
+\
+\  def squish(content)
+\    content.gsub(/\s+/, " ")
+\  end
+\
+\  def upcase_foo
+\    partial.locals[:foo].upcase
+\  end
+\end
 
 <p>\= partial.upcase yield</p>

--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -14,4 +14,4 @@
   end
 %>
 
-<p><%= partial.upcase yield %></p>
+<p>\= partial.upcase yield</p>

--- a/test/fixtures/_partial_with_helpers.html.erb
+++ b/test/fixtures/_partial_with_helpers.html.erb
@@ -1,15 +1,17 @@
-\partial.helpers do
-\  def upcase(content)
-\    content.upcase
-\  end
 \
-\  def squish(content)
-\    content.gsub(/\s+/, " ")
-\  end
+partial.helpers do
+  def upcase(content)
+    content.upcase
+  end
+
+  def squish(content)
+    content.gsub(/\s+/, " ")
+  end
+
+  def upcase_foo
+    partial.locals[:foo].upcase
+  end
+end
 \
-\  def upcase_foo
-\    partial.locals[:foo].upcase
-\  end
-\end
 
 <p>\= partial.upcase yield</p>

--- a/test/fixtures/_strict_locals.html.erb
+++ b/test/fixtures/_strict_locals.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (byline:, header:, title: "Title") %>
-<%= partial.title.h1 %>
-<%= partial.byline.span %>
-<%= partial.header %>
+\# locals: (byline:, header:, title: "Title")
+\= partial.title.h1
+\= partial.byline.span
+\= partial.header

--- a/test/fixtures/_yield_label.html.erb
+++ b/test/fixtures/_yield_label.html.erb
@@ -1,1 +1,1 @@
-<%= partial.label.yield %>
+\= partial.label.yield

--- a/test/fixtures/card_test.html.erb
+++ b/test/fixtures/card_test.html.erb
@@ -1,4 +1,4 @@
-<%= render "card", title: "Some Title" do |partial| %>
-  <% partial.body { _1.p "Lorem Ipsum" } %>
-  <% partial.image.image_tag "https://example.com/image.jpg" %>
-<% end %>
+\= render "card", title: "Some Title" do |partial|
+  \partial.body { _1.p "Lorem Ipsum" }
+  \partial.image.image_tag "https://example.com/image.jpg"
+\end

--- a/test/fixtures/mixed_yield_test.html.erb
+++ b/test/fixtures/mixed_yield_test.html.erb
@@ -1,6 +1,6 @@
-<%= render "yields/mixed" do |partial| %>
-  <% partial.slot do %>
+\= render "yields/mixed" do |partial|
+  \partial.slot do
     <div id="slot">slot content</div>
-  <% end %>
+  \end
   <div id="output_buffer">output buffer content</div>
-<% end %>
+\end

--- a/test/fixtures/mixed_yield_with_object_test.html.erb
+++ b/test/fixtures/mixed_yield_with_object_test.html.erb
@@ -1,6 +1,6 @@
-<%= render "yields/mixed_with_object" do |partial| %>
-  <% partial.slot do |tag| %>
-    <%= tag.div("slot content") %>
-  <% end %>
+\= render "yields/mixed_with_object" do |partial|
+  \partial.slot do |tag|
+    \= tag.div("slot content")
+  \end
   <div id="output_buffer">output buffer content</div>
-<% end %>
+\end

--- a/test/fixtures/translations/_nice_partials_translated.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated.html.erb
@@ -1,3 +1,3 @@
-<%= render("basic") do |partial| %>
-  <%= partial.message.t ".message" %>
-<% end %>
+\= render("basic") do |partial|
+  \= partial.message.t ".message"
+\end

--- a/test/fixtures/translations/_nice_partials_translated_symbol.html.erb
+++ b/test/fixtures/translations/_nice_partials_translated_symbol.html.erb
@@ -1,1 +1,1 @@
-<%= t(:message, scope: "translations.nice_partials_translated_symbol") %>
+\= t(:message, scope: "translations.nice_partials_translated_symbol")

--- a/test/fixtures/translations/_t.html.erb
+++ b/test/fixtures/translations/_t.html.erb
@@ -1,1 +1,1 @@
-<%= partial.t :title, description: :header, byline: "custom.key" %>
+\= partial.t :title, description: :header, byline: "custom.key"

--- a/test/fixtures/translations/_translated.html.erb
+++ b/test/fixtures/translations/_translated.html.erb
@@ -1,1 +1,1 @@
-<%= t ".message" %>
+\= t ".message"

--- a/test/fixtures/translations/_translated.html.erb
+++ b/test/fixtures/translations/_translated.html.erb
@@ -1,1 +1,1 @@
-\= t ".message"
+\t.message

--- a/test/fixtures/yields/_mixed.html.erb
+++ b/test/fixtures/yields/_mixed.html.erb
@@ -1,4 +1,4 @@
 <div id="mixed_yield">
-  <%= partial.slot.yield %>
-  <%= partial.yield %>
+  \= partial.slot.yield
+  \= partial.yield
 </div>

--- a/test/fixtures/yields/_mixed_with_object.html.erb
+++ b/test/fixtures/yields/_mixed_with_object.html.erb
@@ -1,4 +1,4 @@
 <div id="mixed_yield_with_object">
-  <%= partial.slot.yield tag.with_options(id: "yielded_object") %>
-  <%= partial.yield %>
+  \= partial.slot.yield tag.with_options(id: "yielded_object")
+  \= partial.yield
 </div>

--- a/test/fixtures/yields/_object.html.erb
+++ b/test/fixtures/yields/_object.html.erb
@@ -1,1 +1,1 @@
-<%= yield Hash.new(custom_key: :custom_value) %>
+\= yield Hash.new(custom_key: :custom_value)

--- a/test/fixtures/yields/_plain.html.erb
+++ b/test/fixtures/yields/_plain.html.erb
@@ -1,1 +1,1 @@
-<%= yield %>
+\= yield

--- a/test/fixtures/yields/_plain_nested.html.erb
+++ b/test/fixtures/yields/_plain_nested.html.erb
@@ -1,3 +1,3 @@
-<%= render "yields/plain" do %>
-  <%= yield %>
-<% end %>
+\= render "yields/plain" do
+  \= yield
+\end

--- a/test/fixtures/yields/_symbol.html.erb
+++ b/test/fixtures/yields/_symbol.html.erb
@@ -1,1 +1,1 @@
-<%= yield :message %>
+\= yield :message

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -13,6 +13,8 @@ class RendererTest < NicePartials::Test
     assert_text "Some Title"
     assert_css "p", class: "text-bold", text: "Lorem Ipsum"
     assert_css("img") { assert_equal "https://example.com/image.jpg", _1["src"] }
+
+    puts rendered
   end
 
   test "render partial can yield block named label" do
@@ -187,7 +189,7 @@ class RendererTest < NicePartials::Test
   end
 
   test "doesn't clobber Kernel.p" do
-    assert_output "\"it's clobbering time\"\n" do
+    assert_output /"it's clobbering time"\n/ do
       render("clobberer") { |p| p.content_for :message, "hello from nice partials" }
     end
 

--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -198,7 +198,7 @@ class RendererTest < NicePartials::Test
 
   test "deprecates top-level access through p method" do
     assert_deprecated /p is deprecated and will be removed from nice_partials \d/, NicePartials::DEPRECATOR do
-      assert_output "\"it's clobbering time\"\n" do
+      assert_output /"it's clobbering time"\n/ do
         render("clobberer") { |p| p.content_for :message, "hello from nice partials" }
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,9 @@ module BRB::Sigils
   register :attributes, '\= tag.attributes(\1)'
   register :p, '\= tag.attributes(\1)'
   register :data, '\= tag.attributes(data: \1)'
+  register :lorem, <<~end_of_lorem
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  end_of_lorem
 end
 
 class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,3 +27,19 @@ class NicePartials::Test < ActionView::TestCase
     @page ||= Capybara.string(rendered)
   end
 end
+
+module BRB; end
+class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
+  # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+  # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
+
+  def initialize(input, ...)
+    old_input = input.dup
+    if input.gsub!(/\\(?!s\+)(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1%>\2')
+      # puts [old_input, input] unless input.include?("clobbering")
+    end
+    super
+  end
+end
+
+ActionView::Template::Handlers::ERB.erb_implementation = BRB::Erubi

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,26 @@ class NicePartials::Test < ActionView::TestCase
   end
 end
 
+# Here's BRB with preprocessing sigils. Sigils aim to make actions common in an HTML context easier to write.
+# At template compile time the sigils are `gsub`'ed into their replacements.
+#
+# They follow this syntax, here `sigil_name` is the name of the Sigil:
+#
+#   \sigil_name # A sigil with no arguments
+#   \sigil_name(< ruby expression >) # A sigil with arguments, must be called with ()
+#
+# Examples:
+#
+#   \class(active: post.active?) -> class="<%= class_names(active: post.active?) %>"
+#   \attributes(post.options) -> <%= tag.attributes(post.options) %>
+#   \p(post.options) -> <%= tag.attributes(post.options) %>
+#   \data(post.data) -> <%= tag.attributes(data: post.data) %>
+#   \lorem -> Lorem ipsum dolor sit amet…
+#
+# There's also a `t` sigil, but that's a little more involved since there's some extra things to condense:
+#
+#   \t.message -> <%= t ".message" %>
+#   \t Some bare words -> <%= t "Some bare words" %> # Assumes we're using a gettext I18n backend, coming later!
 module BRB; end
 module BRB::Sigils
   @values = {}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,6 +54,18 @@ class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
   # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
   # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
 
+  # BRB aims to be a simpler syntax, but still a superset of ERB, that's aware of the context we're in: HTML.
+  #
+  # We're replacing <% %>, <%= %>, and <%# %> with \, \= and \# — these are self-terminating expressions.
+  #
+  # We recognize these contexts and convert them to their terminated ERB equivalent:
+  #
+  # 1. A plain Ruby line: \puts "yo" -> <%puts "yo" %>
+  # 2. Within a tag: <h1>\= post.title</h1> -> <h1><%= post.title %></h1>
+  # 3. Within attributes at the end: <h1 \= post.options></h1> -> <h1 aria-labelledby="title"></h1>
+  # 4. Within attributes:
+  #    <h1 \= post.options \= class_names(active: post.active?) data-controller="title"></h1> ->
+  #    <h1 aria-labelledby="title" class="active"data-controller="title"></h1>
   def initialize(input, ...)
     puts input
     # scanner = StringScanner.new(input)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,23 @@ class NicePartials::Test < ActionView::TestCase
   end
 end
 
-module BRB; end
+module BRB
+  singleton_class.attr_reader :sigils
+  @sigils = {}
+
+  def self.replace_sigils(source)
+    source.gsub!(/\(?#{sigils.keys.join("|")})=?\((.*?)\)/, sigils)
+  end
+
+  def self.gsub_sigil(key, replacer)
+    sigils[key.to_s] = replacer
+  end
+
+  gsub_sigil :class, %s(class="\= class_names(\1)")
+  gsub_sigil :attributes, 'tag.attributes(\1)'
+  gsub_sigil :data, 'tag.attributes(data: \1)'
+end
+
 class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
   # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m
   # DEFAULT_REGEXP = /<%(={1,2}|-|\#|%)?(.*?)([-=])?%>([ \t]*\r?\n)?/m

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
 
   def initialize(input, ...)
     old_input = input.dup
-    if input.gsub!(/\\(?!s\+)(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1%>\2')
+    if input.gsub!(/\\(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1 %>\2')
       # puts [old_input, input] unless input.include?("clobbering")
     end
     super

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,8 +35,12 @@ class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
 
   def initialize(input, ...)
     old_input = input.dup
-    if input.gsub!(/\\(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1 %>\2')
-      # puts [old_input, input] unless input.include?("clobbering")
+    if input.gsub!(/^\\\r?\n(.*?)^\\\r?\n/m, "<%\n\\1%>\n")
+      puts ["group", old_input, input] unless input.include?("clobbering")
+    end
+
+    if input.gsub!(/(?<!\/)\\(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1%>\2')
+      puts ["line", old_input, input] unless input.include?("clobbering")
     end
     super
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,16 +52,28 @@ class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
 
   def initialize(input, ...)
     old_input = input.dup
+
+    # puts old_input
+
+    # scanner = StringScanner.new(input)
+    # while string = scanner.scan_until(/\\/)
+    #   binding.irb
+    #   if scanner.bol? && scanner.check(/\n/)
+    #     puts "YO"
+    #   end
+    #   p string
+    # end
+
     if BRB::Sigils.gsub!(input)
-      puts ["sigils", old_input, input] unless input.include?("clobbering")
+      # puts ["sigils", old_input, input] unless input.include?("clobbering")
     end
 
     if input.gsub!(/^\\\r?\n(.*?)^\\\r?\n/m, "<%\n\\1%>\n")
-      puts ["group", old_input, input] unless input.include?("clobbering")
+      # puts ["group", old_input, input] unless input.include?("clobbering")
     end
 
     if input.gsub!(/(?<!\/)\\(.*?)(\<\/|[ \t]*\r?\n)/, '<%\1%>\2')
-      puts ["line", old_input, input] unless input.include?("clobbering")
+      # puts ["line", old_input, input] unless input.include?("clobbering")
     end
     super
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,7 +73,8 @@ class BRB::Erubi < ::ActionView::Template::Handlers::ERB::Erubi
       # puts ["group", input] unless input.include?("clobbering")
     end
 
-    if input.gsub!(/(?<!\/)\\(.*?)(\"?\>|\<\/|[ \t]*\r?\n)/, '<%\1 %>\2')
+    # if input.gsub!(/(?<!\/)\\(.*?)(\"?\>|\<\/|[ \t]*\r?\n)/, '<%\1 %>\2')
+    if input.gsub!(/(?<!\/)\\(.*?)(?=\n|"? \\|"?>|<\/|(?<!\/)\\|[a-z-]+=)/, '<%\1 %>')
       puts ["line", input] unless input.include?("clobbering")
     end
     super


### PR DESCRIPTION
This is just a test for a templating idea I've had for a while.

ERB tags `<% %>` and `<%= %>` feel so noisy, having to add `%>` a Ruby line feels as if I'd had to write `;` to end my Ruby lines. So what if we had a simpler syntax that can figure out how to auto-close for us.

So stuff like this becomes possible:

```erb
\@posts.each do |post|
  <h1>\= post.title</h1>

  \= render "post/body", post: post
\end
```