### PR TITLE
Remove confusing double `title` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See, here we're outputting the `image`, `title`, and `body` sections:
 Then in `render` we populate them:
 
 ```html+erb
-<%= render "components/card", title: "Some Title" do |partial| %>
+<%= render "components/card" do |partial| %>
   <% partial.title t(".title") %> # Same as `partial.content_for :title, t(".title")`
 
   <% partial.body do %>


### PR DESCRIPTION
I was reading documentation for nice_partials and realized, through examples in the `README.md` that variables passed in as `local_assigns` as well as variables passed in inside the block by calling the variable name on the `partial` variable, actually have their values concatenated.
This is explained down in the `README.md`, but the very first example is confusing, because, before knowing, I thought that `title:` and `partial.title` are either two separate variables or that the value of `title:` is overwritten by the value of `partial.title`.

What acutally happens is that the value of `title:` is concatenated with the value of `partial.title` and the result is passed to the partial as `partial.title`.
Here's an example:

```html+erb
<%= render "components/card", title: "Some Title" do |partial| %>
  <% partial.title "Upcoming event" %>

  <% partial.body do %>
    Lorem ipsum dolor sit amet, …
  <% end %>
<% end %>
```

```html+erb
<div class="card">
  <div class="card-body">
    <h5 class="card-title"><%= partial.title %></h5>
    <% if partial.body? %>
      <p class="card-text">
        <%= partial.body %>
      </p>
    <% end %>
  </div>
</div>
```

The output of the above is:

```html
<div class="card">
  <div class="card-body">
    <h5 class="card-title">Some TitleUpcoming event</h5>
      <p class="card-text">
            Lorem ipsum dolor sit amet, …

      </p>
  </div>
</div>
```

I actually tested this in a Bullet Train app. :)
I'd just remove the mention of `title: "Some Title"` in the first example.