### PR TITLE
Support rendering partials from controller renderers

### DIFF
--- a/test/renderer_test.rb
+++ b/test/renderer_test.rb
@@ -55,6 +55,14 @@ class RendererTest < NicePartials::Test
     assert_css "p", text: "UPCASED"
   end
 
+  test "TestController.render partial that declares helper methods" do
+    TestController.renderer.render partial: "partial_with_helpers" do
+      "upcased"
+    end
+
+    assert_css "p", text: "UPCASED"
+  end
+
   test "render partial exposes helper methods to callers" do
     render "partial_with_helpers" do |partial|
       partial.squish "text with       spaces"


### PR DESCRIPTION
Gems like [turbo-rails][] utilize the
[ActionController::Renderer.renderer][] class method to render templates and partials outside the context of a request-response cycle.

Prior to this bugfix, partials rendered by controller renderers raised errors like the following:

```
Error:
RendererTest#test_TestController.render_partial_that_declares_helper_methods:
ActionView::Template::Error: undefined method `helpers' for nil:NilClass
    bullet-train-co/nice_partials/test/fixtures/_partial_with_helpers.html.erb:2:in `_fixtures__partial_with_helpers_html_erb__3099800394007487670_4260'
```

[ActionController::Renderer.renderer]: https://edgeapi.rubyonrails.org/classes/ActionController/Renderer.html#method-i-render
[turbo-rails]: https://github.com/hotwired/turbo-rails/blob/e44b6a98a77a0a2cc927f986a67517d73c4c9246/app/channels/turbo/streams/broadcasts.rb#L87